### PR TITLE
Remove overrides of primary_keys

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -3,8 +3,8 @@ require_relative "../../lib/course_contract_tests/lib/reference_test"
 class CoursesController < ApplicationController
   def index
 
-    @campus = Campus.find(params[:campus_id])
-    @term = Term.find(params[:term_id])
+    @campus = Campus.where(abbreviation: params[:campus_id].upcase).first
+    @term = Term.where(strm: params[:term_id]).first
 
     @courses = [OpenStruct.new(type: "course", id: "2066",
       catalog_number: "1101W",

--- a/app/models/campus.rb
+++ b/app/models/campus.rb
@@ -4,8 +4,6 @@ class Campus < ::ActiveRecord::Base
 
   attr_accessor :type
 
-  self.primary_key = "abbreviation"
-
   def type
     "campus"
   end

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -4,8 +4,6 @@ class Term < ::ActiveRecord::Base
 
   attr_accessor :type
 
-  self.primary_key = "strm"
-
   def type
     "term"
   end

--- a/spec/models/campus_spec.rb
+++ b/spec/models/campus_spec.rb
@@ -20,13 +20,6 @@ RSpec.describe Campus do
     end
   end
 
-  describe "id" do
-    it "is the abbreviation" do
-      campus_instance.abbreviation = "UMNTC"
-      expect(campus_instance.id).to eq("UMNTC")
-    end
-  end
-
   describe "valid?" do
     it "is valid if the abbrevation is unique" do
       expect(described_class.new(abbreviation: "UMNRO").valid?).to be_truthy

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -20,13 +20,6 @@ RSpec.describe Term do
     end
   end
 
-  describe "id" do
-    it "is the strm" do
-      term_instance.strm = "1149"
-      expect(term_instance.id).to eq("1149")
-    end
-  end
-
   describe "valid?" do
     it "is valid if the abbrevation is unique" do
       expect(described_class.new(strm: "1149").valid?).to be_truthy


### PR DESCRIPTION
Oracle (or the oracle adapter, I'm not sure), does not like it when I
override an active_record primary_key. Attempts to save record results
in errors about NULL id fields. This primary_key overriding was a little
weird anyway, so I'm taking it out.

This also means I have to change the finders used in the
courses_controller, since they can no longer use the basic `find` method