### PR TITLE
complete rabl templates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.0'
-gem 'rails-api', '0.4.0'
-
 
 group :production, :staging do
   gem 'ruby-oci8', '2.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,9 +95,6 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.0)
       sprockets-rails
-    rails-api (0.4.0)
-      actionpack (>= 3.2.11)
-      railties (>= 3.2.11)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.5)
@@ -166,7 +163,6 @@ DEPENDENCIES
   oj
   rabl
   rails (= 4.2.0)
-  rails-api (= 0.4.0)
   rspec (~> 3.2)
   rspec-rails (~> 3.2)
   ruby-oci8 (= 2.1.7)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
-class ApplicationController < ActionController::API
+class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   #protect_from_forgery with: :exception

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -10,6 +10,22 @@ class CoursesController < ApplicationController
 
     @courses = j["courses"].map { |x| OpenStruct.new(x) }
 
+    @courses.each do |c|
+      c.subject = OpenStruct.new(c.subject)
+      c.attributes.map! { |x| OpenStruct.new(x) }
+      c.sections.map! { |x| OpenStruct.new(x) }
+
+      c.sections.each do |s|
+        s.instruction_mode = OpenStruct.new(s.instruction_mode)
+        s.grading_basis = OpenStruct.new(s.grading_basis)
+        s.instructors.map! { |i| OpenStruct.new(i) }
+        s.meeting_patterns.map! { |m| OpenStruct.new(m) }
+
+        s.meeting_patterns.each do |m|
+          m.location = OpenStruct.new(m.location)
+        end
+      end
+    end
 
     respond_to do |format|
       format.xml

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,16 +1,15 @@
 class CoursesController < ApplicationController
   def index
-
-    @campus = Campus.where(abbreviation: params[:campus_id].upcase).first
-    @term = Term.where(strm: params[:term_id]).first
+    campus = Campus.where(abbreviation: params[:campus_id].upcase).first
+    term = Term.where(strm: params[:term_id]).first
 
     f = File.open('test/fixtures/courses_example.json')
 
     j = JSON.parse(f.read)
 
-    @courses = j["courses"].map { |x| OpenStruct.new(x) }
+    courses = j["courses"].map { |x| OpenStruct.new(x) }
 
-    @courses.each do |c|
+    courses.each do |c|
       c.subject = OpenStruct.new(c.subject)
       c.attributes.map! { |x| OpenStruct.new(x) }
       c.sections.map! { |x| OpenStruct.new(x) }
@@ -26,6 +25,11 @@ class CoursesController < ApplicationController
         end
       end
     end
+
+    @courses = CoursesPresenter.new
+    @courses.campus = campus
+    @courses.term = term
+    @courses.courses = courses
 
     respond_to do |format|
       format.xml

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -10,7 +10,11 @@ class CoursesController < ApplicationController
 
     @courses = j["courses"].map { |x| OpenStruct.new(x) }
 
-    render
+
+    respond_to do |format|
+      format.xml
+      format.json
+    end
   end
 
   def create

--- a/app/models/courses_presenter.rb
+++ b/app/models/courses_presenter.rb
@@ -1,0 +1,4 @@
+class CoursesPresenter
+  attr_accessor :campus, :term, :courses
+
+end

--- a/app/views/campuses/index.rabl
+++ b/app/views/campuses/index.rabl
@@ -1,2 +1,2 @@
-collection @campuses
-attributes :type, :id, :abbreviation, :campus_id
+collection @campuses, :root => false, :object_root => false
+extends("campuses/show")

--- a/app/views/campuses/show.rabl
+++ b/app/views/campuses/show.rabl
@@ -1,0 +1,2 @@
+object @campus
+attributes :type, :id, :abbreviation, :campus_id

--- a/app/views/courses/index.rabl
+++ b/app/views/courses/index.rabl
@@ -1,6 +1,13 @@
 object false
-child(@campus) {attributes :type, :campus_id, :id, :abbreviation}
-child(@term => :term) {attributes :type, :term_id, :id, :strm}
+
+node :campus do
+  partial "campuses/show", object: @campus
+end
+
+node :term do
+  partial "terms/show", object: @term
+end
+
 child(@courses => :courses) do
   collection @courses, :root => false, :object_root => false
   attributes :type, :course_id, :id, :catalog_number, :description, :title

--- a/app/views/courses/index.rabl
+++ b/app/views/courses/index.rabl
@@ -3,5 +3,41 @@ child(@campus) {attributes :type, :campus_id, :id, :abbreviation}
 child(@term => :term) {attributes :type, :term_id, :id, :strm}
 child(@courses => :courses) do
   collection @courses, :root => false, :object_root => false
-  attributes :type, :course_id, :id, :catalog_number, :description, :title, :subject, :attributes, :sections
+  attributes :type, :course_id, :id, :catalog_number, :description, :title
+
+  child :subject => :subject do
+    attributes :type, :subject_id, :id, :description
+  end
+
+  child :attributes => :attributes do
+    collection attributes, :root => false, :object_root => false
+    attributes :type, :attribute_id, :id, :family
+  end
+
+  child :sections => :sections do
+    collection attributes, :root => false, :object_root => false
+    attributes :type, :id, :class_number, :number, :component, :location, :credits_maximum, :credits_minimum, :notes
+
+    child :instruction_mode => :instruction_mode do
+      attributes :type, :instruction_mode_id, :id, :description
+    end
+
+    child :grading_basis => :grading_basis do
+      attributes :type, :grading_basis_id, :id, :description
+    end
+
+    child :instructors => :instructors do
+      collection attributes, :root => false, :object_root => false
+      attributes :type, :employee_id, :id, :name, :email, :role
+    end
+
+    child :meeting_patterns => :meeting_patterns do
+      collection attributes, :root => false, :object_root => false
+      attributes :type, :start_time, :end_time, :start_date, :end_date
+
+      child :location => :location do
+        attributes :type, :location_id, :id, :description
+      end
+    end
+  end
 end

--- a/app/views/courses/index.rabl
+++ b/app/views/courses/index.rabl
@@ -1,50 +1,13 @@
-object false
+object @courses
 
 node :campus do
-  partial "campuses/show", object: @campus
+  partial "campuses/show", object: @courses.campus
 end
 
 node :term do
-  partial "terms/show", object: @term
+  partial "terms/show", object: @courses.term
 end
 
-child(@courses => :courses) do
-  collection @courses, :root => false, :object_root => false
-  attributes :type, :course_id, :id, :catalog_number, :description, :title
-
-  child :subject => :subject do
-    attributes :type, :subject_id, :id, :description
-  end
-
-  child :attributes => :attributes do
-    collection attributes, :root => false, :object_root => false
-    attributes :type, :attribute_id, :id, :family
-  end
-
-  child :sections => :sections do
-    collection attributes, :root => false, :object_root => false
-    attributes :type, :id, :class_number, :number, :component, :location, :credits_maximum, :credits_minimum, :notes
-
-    child :instruction_mode => :instruction_mode do
-      attributes :type, :instruction_mode_id, :id, :description
-    end
-
-    child :grading_basis => :grading_basis do
-      attributes :type, :grading_basis_id, :id, :description
-    end
-
-    child :instructors => :instructors do
-      collection attributes, :root => false, :object_root => false
-      attributes :type, :employee_id, :id, :name, :email, :role
-    end
-
-    child :meeting_patterns => :meeting_patterns do
-      collection attributes, :root => false, :object_root => false
-      attributes :type, :start_time, :end_time, :start_date, :end_date
-
-      child :location => :location do
-        attributes :type, :location_id, :id, :description
-      end
-    end
-  end
+child :courses => :courses do
+  extends "courses/show"
 end

--- a/app/views/courses/show.rabl
+++ b/app/views/courses/show.rabl
@@ -1,0 +1,38 @@
+object @course
+attributes :type, :course_id, :id, :catalog_number, :description, :title
+
+child :subject => :subject do
+  attributes :type, :subject_id, :id, :description
+end
+
+child :attributes => :attributes do
+  collection attributes, :root => false, :object_root => false
+  attributes :type, :attribute_id, :id, :family
+end
+
+child :sections => :sections do
+  collection attributes, :root => false, :object_root => false
+  attributes :type, :id, :class_number, :number, :component, :location, :credits_maximum, :credits_minimum, :notes
+
+  child :instruction_mode => :instruction_mode do
+    attributes :type, :instruction_mode_id, :id, :description
+  end
+
+  child :grading_basis => :grading_basis do
+    attributes :type, :grading_basis_id, :id, :description
+  end
+
+  child :instructors => :instructors do
+    collection attributes, :root => false, :object_root => false
+    attributes :type, :employee_id, :id, :name, :email, :role
+  end
+
+  child :meeting_patterns => :meeting_patterns do
+    collection attributes, :root => false, :object_root => false
+    attributes :type, :start_time, :end_time, :start_date, :end_date
+
+    child :location => :location do
+      attributes :type, :location_id, :id, :description
+    end
+  end
+end

--- a/app/views/terms/index.rabl
+++ b/app/views/terms/index.rabl
@@ -1,2 +1,2 @@
-collection @terms
-attributes :type, :id, :strm
+collection @terms, :root => false, :object_root => false
+extends("terms/show")

--- a/app/views/terms/show.rabl
+++ b/app/views/terms/show.rabl
@@ -1,0 +1,2 @@
+object @term
+attributes :type, :id, :strm

--- a/app/views/terms/show.rabl
+++ b/app/views/terms/show.rabl
@@ -1,2 +1,2 @@
 object @term
-attributes :type, :id, :strm
+attributes :type, :term_id, :id, :strm

--- a/config/initializers/rabl.rb
+++ b/config/initializers/rabl.rb
@@ -1,0 +1,5 @@
+require 'rabl'
+Rabl.configure do |config|
+  config.include_json_root = false
+  config.include_child_root = false
+end

--- a/spec/requests/get_campuses_spec.rb
+++ b/spec/requests/get_campuses_spec.rb
@@ -11,12 +11,7 @@ RSpec.describe "get campuses" do
       get "/campuses"
 
       JSON.parse(response.body).each do |row|
-
-        expect(row.keys).to include('campus')
-
-        row.keys.each do |key|
-          expect(row[key]).to include('type', 'abbreviation', 'id')
-        end
+        expect(row.keys).to include('type', 'abbreviation', 'id')
       end
     end
   end

--- a/spec/requests/get_terms_spec.rb
+++ b/spec/requests/get_terms_spec.rb
@@ -11,12 +11,7 @@ RSpec.describe "get terms" do
       get "/terms"
 
       JSON.parse(response.body).each do |row|
-
-        expect(row.keys).to include('term')
-
-        row.keys.each do |key|
-          expect(row[key]).to include('type', 'strm', 'id')
-        end
+        expect(row.keys).to include('type', 'term_id', 'strm', 'id')
       end
     end
   end


### PR DESCRIPTION
Main changes:

- Full rabl template for a course, complete with all sub-resources
- Using rabl's partials to re-use templates
- Removed Rails::API as it wouldn't let me set an xml content type (or I couldn't figure out how to do it)
- Introduce CoursesPresenter so that the CoursesController#index only sets one instance var
