### PR TITLE
pull course model data from data store

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -41,15 +41,20 @@ class CoursesController < ApplicationController
     begin
       campus_attr = params[:course]["campus"].permit(:abbreviation, :type, :id)
       resources = []
-      resources << Campus.new(campus_attr)
+      campus = Campus.new(campus_attr)
+      resources << campus
 
       term_attr = params[:course]["term"].permit(:strm, :type, :id)
-      resources << Term.new(term_attr)
+      term = Term.new(term_attr)
+      resources << term
 
       params[:course]["courses"].each do |course|
         course_attr = course.permit(:id, :course_id, :type, :catalog_number, :description, :title, :subject, :attributes, :sections)
-        course_attr[:campus_id] = params[:course]["campus"][:id]
-        course_attr[:term_id] = params[:course]["term"][:id]
+
+        course_attr[:campus_id] = campus.id
+
+        course_attr[:term_id] = term.id
+
         resources << Course.new(course_attr)
       end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -7,18 +7,28 @@ class CoursesController < ApplicationController
 
     j = JSON.parse(f.read)
 
-    courses = j["courses"].map { |x| OpenStruct.new(x) }
+    courses = Course.where(campus_id: campus.id, term_id: term.id)
 
     courses.each do |c|
-      c.subject = OpenStruct.new(c.subject)
-      c.attributes.map! { |x| OpenStruct.new(x) }
-      c.sections.map! { |x| OpenStruct.new(x) }
+
+      json_course = j["courses"].detect{ |x| x["course_id"] == c.course_id }
+
+      c.subject = OpenStruct.new(json_course["subject"])
+      c.cle_attributes = json_course["cle_attributes"].map { |x| OpenStruct.new(x) }
+
+      c.sections = json_course["sections"].map { |x| OpenStruct.new(x) }
 
       c.sections.each do |s|
-        s.instruction_mode = OpenStruct.new(s.instruction_mode)
-        s.grading_basis = OpenStruct.new(s.grading_basis)
-        s.instructors.map! { |i| OpenStruct.new(i) }
-        s.meeting_patterns.map! { |m| OpenStruct.new(m) }
+        s.instruction_mode = OpenStruct.new(Hash[s.instruction_mode.map { |key, value| [key, value] }])
+        s.grading_basis = OpenStruct.new(Hash[s.grading_basis.map { |key, value| [key, value] }])
+
+        s.instructors.each do
+          s.instructors = s.instructors.map { |x| OpenStruct.new(x) }
+        end
+
+        s.meeting_patterns.each do |m|
+          s.meeting_patterns = s.meeting_patterns.map { |x| OpenStruct.new(x) }
+        end
 
         s.meeting_patterns.each do |m|
           m.location = OpenStruct.new(m.location)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -5,7 +5,7 @@ class Course < ::ActiveRecord::Base
   validates_presence_of :term_id, :campus_id, :course_id
   validates_uniqueness_of :course_id, scope: [:term_id, :campus_id]
 
-  attr_accessor :type
+  attr_accessor :type, :subject, :cle_attributes, :sections
 
   self.primary_key = "id"
 

--- a/app/views/courses/show.rabl
+++ b/app/views/courses/show.rabl
@@ -5,7 +5,7 @@ child :subject => :subject do
   attributes :type, :subject_id, :id, :description
 end
 
-child :attributes => :attributes do
+child :cle_attributes => :cle_attributes do
   collection attributes, :root => false, :object_root => false
   attributes :type, :attribute_id, :id, :family
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,6 +8,7 @@
 #
 Campus.delete_all
 Term.delete_all
+Course.delete_all
 
 %w(UMNTC UMNDL UMNMO UMNRC UMNRO).each do |abbreviation|
   Campus.create({abbreviation: abbreviation})
@@ -16,3 +17,21 @@ end
 %w(1149 1155 1159 1163).each do |strm|
   Term.create({strm: strm})
 end
+
+f = File.open('test/fixtures/courses_example.json')
+
+j = JSON.parse(f.read)
+
+j["courses"].each do |course|
+  course_attr = Hash.new
+  course_attr = course.slice("title", "description", "course_id", "catalog_number")
+
+  campus = Campus.where(abbreviation: j["campus"]["abbreviation"]).first
+  course_attr[:campus_id] = campus.id
+
+  term = Term.where(strm: j["term"]["strm"]).first
+  course_attr[:term_id] = term.id
+
+  Course.create(course_attr)
+end
+

--- a/spec/requests/create_courses_spec.rb
+++ b/spec/requests/create_courses_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "create course" do
   before(:each) do
     Term.delete_all
     Campus.delete_all
+    Course.delete_all
   end
 
   describe "when passed valid syntax" do

--- a/spec/requests/get_courses_spec.rb
+++ b/spec/requests/get_courses_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "get courses" do
 
   describe "as json" do
     it "returns a structure that matches our reference structure " do
-      get "/campuses/UMNTC/terms/1159/courses.json"
+      get "/campuses/UMNTC/terms/1149/courses.json"
 
       parsed_response = JSON.parse(response.body)
       expect { ReferenceTest.test_structure(parsed_response) }.not_to raise_error

--- a/test/fixtures/courses_example.json
+++ b/test/fixtures/courses_example.json
@@ -25,7 +25,7 @@
         "id": 10000,
         "description": "Physics"
       },
-      "attributes": [
+      "cle_attributes": [
         {
           "type": "attribute",
           "id": 10000,


### PR DESCRIPTION
Now that we have a course model, the controller has been updated to pull what it can from the data store instead of using the json reference file. We are still using the reference file for the data we are not currently storing in the data store - as new models are added, this will be updated.