### PR TITLE
Configure Capistrano to run migrations on deploy

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -20,7 +20,7 @@ require 'capistrano/deploy'
 # require 'capistrano/chruby'
 require 'capistrano/bundler'
 # require 'capistrano/rails/assets'
-# require 'capistrano/rails/migrations'
+require 'capistrano/rails/migrations'
 # require 'capistrano/passenger'
 
 # Load custom tasks from `lib/capistrano/tasks' if you have any defined

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -4,7 +4,7 @@ role :web, %w{asr-course-production.oit.umn.edu}
 # Configuration
 set :user, 'swadm'
 set :server, 'asr-course-production.oit.umn.edu'
-set :roles, %w{web app}
+set :roles, %w{web app db}
 set :web_root, '/swadm/www/courses.umn.edu'
 set :deploy_to, "#{fetch(:web_root)}"
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -4,7 +4,7 @@ role :web, %w{asr-course-staging.oit.umn.edu}
 # Configuration
 set :user, 'swadm'
 set :server, 'asr-course-staging.oit.umn.edu'
-set :roles, %w{web app}
+set :roles, %w{web app db}
 set :web_root, '/swadm/www/courses-staging.umn.edu'
 set :deploy_to, "#{fetch(:web_root)}"
 


### PR DESCRIPTION
This requires two changes. First, include the rails/migrations file.
2nd, give the deploy the 'db' role

Fixes #18