### PR TITLE
Remove rspec require

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,4 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
-require "rspec/core/rake_task"
 task default: [:spec]


### PR DESCRIPTION
This require prevents rake usage when this app is deployed, since the
deployed version don't install rspec.

But it turns out this require isn't even necessary, because of
rspec-rails. I discovered that here:
http://stackoverflow.com/questions/16812989/how-should-i-structure-a-rakefile-with-some-tasks-that-need-to-run-during-deploy#comment24404027_16853639

I did a test deploy with this line removed and Rake tasks work on the
server. And tests still work when doing development locally.

Fixes #19