### PR TITLE
JSON Import Tweaks - Add Equivalency, Support for Optional Resources

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -75,8 +75,10 @@ class CoursesController < ApplicationController
             mp_attr = pattern_data.permit(:start_time, :end_time, :start_date, :end_date)
             mp = section.meeting_patterns.find_or_create_by(mp_attr)
 
-            location_attr = pattern_data[:location].permit(:location_id, :description)
-            mp.location = Location.find_or_create_by(location_attr)
+            location_data = pattern_data[:location]
+            if location_data
+              mp.location = Location.find_or_create_by(location_data.permit(:location_id, :description))
+            end
 
             pattern_data[:days].each do |day|
               day_attr = day.permit(:abbreviation, :name)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -46,6 +46,11 @@ class CoursesController < ApplicationController
           ret << CourseAttribute.find_or_create_by(attribute_id: attribute["attribute_id"], family: attribute["family"])
         end
 
+        equivalency_data = course_data["equivalency"]
+        if equivalency_data
+          course.equivalency = Equivalency.find_or_create_by(equivalency_id: equivalency_data["equivalency_id"])
+        end
+
         course.save
 
         course_data["sections"].each do |section_data|

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -24,12 +24,10 @@ class CoursesController < ApplicationController
   def create
     begin
       campus_attr = params[:course]["campus"].permit(:abbreviation)
-      campus = Campus.new(campus_attr)
-      campus.save
+      campus = Campus.find_or_create_by(campus_attr)
 
       term_attr = params[:course]["term"].permit(:strm)
-      term = Term.new(term_attr)
-      term.save
+      term = Term.find_or_create_by(term_attr)
 
       params[:course]["courses"].each do |course_data|
         course_attr = course_data.permit(:id, :course_id, :catalog_number, :description, :title, :sections)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,6 +2,7 @@ class Course < ::ActiveRecord::Base
   belongs_to :term
   belongs_to :campus
   belongs_to :subject
+  belongs_to :equivalency
   has_and_belongs_to_many :course_attributes
   has_many :sections
 

--- a/app/models/equivalency.rb
+++ b/app/models/equivalency.rb
@@ -1,0 +1,8 @@
+class Equivalency < ActiveRecord::Base
+
+  validates :equivalency_id, presence: true, uniqueness: true
+
+  def type
+    "equivalency"
+  end
+end

--- a/app/models/equivalency.rb
+++ b/app/models/equivalency.rb
@@ -1,5 +1,7 @@
 class Equivalency < ActiveRecord::Base
 
+  has_many :courses
+
   validates :equivalency_id, presence: true, uniqueness: true
 
   def type

--- a/db/migrate/20150323143938_create_equivalencies.rb
+++ b/db/migrate/20150323143938_create_equivalencies.rb
@@ -1,0 +1,7 @@
+class CreateEquivalencies < ActiveRecord::Migration
+  def change
+    create_table :equivalencies do |t|
+      t.string :equivalency_id
+    end
+  end
+end

--- a/db/migrate/20150323151217_add_equivalency_association_to_courses.rb
+++ b/db/migrate/20150323151217_add_equivalency_association_to_courses.rb
@@ -1,0 +1,7 @@
+class AddEquivalencyAssociationToCourses < ActiveRecord::Migration
+  def change
+    change_table :courses do |t|
+      t.belongs_to :equivalency, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150323143938) do
+ActiveRecord::Schema.define(version: 20150323151217) do
 
   create_table "campuses", force: :cascade do |t|
     t.string "abbreviation"
@@ -47,9 +47,11 @@ ActiveRecord::Schema.define(version: 20150323143938) do
     t.string  "description"
     t.string  "catalog_number"
     t.integer "subject_id"
+    t.integer "equivalency_id"
   end
 
   add_index "courses", ["campus_id"], name: "index_courses_on_campus_id"
+  add_index "courses", ["equivalency_id"], name: "index_courses_on_equivalency_id"
   add_index "courses", ["subject_id"], name: "index_courses_on_subject_id"
   add_index "courses", ["term_id"], name: "index_courses_on_term_id"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150318020754) do
+ActiveRecord::Schema.define(version: 20150323143938) do
 
   create_table "campuses", force: :cascade do |t|
     t.string "abbreviation"
@@ -65,6 +65,10 @@ ActiveRecord::Schema.define(version: 20150318020754) do
 
   add_index "days_meeting_patterns", ["day_id"], name: "index_days_meeting_patterns_on_day_id"
   add_index "days_meeting_patterns", ["meeting_pattern_id"], name: "index_days_meeting_patterns_on_meeting_pattern_id"
+
+  create_table "equivalencies", force: :cascade do |t|
+    t.string "equivalency_id"
+  end
 
   create_table "grading_bases", force: :cascade do |t|
     t.string "grading_basis_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -89,7 +89,7 @@ j["courses"].each do |course_json|
 
       location_json = pattern_json["location"]
       if location_json
-        Location.find_or_create_by(location_json.slice("location_id","description"))
+        mp.location = Location.find_or_create_by(location_json.slice("location_id","description"))
       end
 
       pattern_json["days"].each do |day|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,7 +56,7 @@ j["courses"].each do |course_json|
   term = Term.where(strm: j["term"]["strm"]).first
   course_attr[:term_id] = term.id
 
-  subject = Subject.create(course_json["subject"].slice("subject_id", "description"))
+  subject = Subject.find_or_create_by(course_json["subject"].slice("subject_id", "description"))
   course_attr[:subject_id] = subject.id
 
   equivalency_json = course_json["equivalency"]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -86,7 +86,12 @@ j["courses"].each do |course_json|
 
     section_json["meeting_patterns"].each do |pattern_json|
       mp = section.meeting_patterns.create(pattern_json.slice("start_time","end_time","start_date","end_date"))
-      mp.location = Location.find_or_create_by(pattern_json["location"].slice("location_id","description"))
+
+      location_json = pattern_json["location"]
+      if location_json
+        Location.find_or_create_by(location_json.slice("location_id","description"))
+      end
+
       pattern_json["days"].each do |day|
         mp.days << Day.find_by_abbreviation(day["abbreviation"])
       end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,6 +59,12 @@ j["courses"].each do |course_json|
   subject = Subject.create(course_json["subject"].slice("subject_id", "description"))
   course_attr[:subject_id] = subject.id
 
+  equivalency_json = course_json["equivalency"]
+  if equivalency_json
+    equivalency = Equivalency.find_or_create_by(equivalency_json.slice("equivalency_id"))
+    course_attr[:equivalency_id] = equivalency.id
+  end
+
   @course = Course.create(course_attr)
 
   attributes = course_json["cle_attributes"].map { |a| CourseAttribute.where(attribute_id: a["attribute_id"]).first }

--- a/spec/models/equivalency_spec.rb
+++ b/spec/models/equivalency_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Equivalency do
+  let(:subject_instance) { described_class.new }
+
+  describe "#type" do
+    it "is 'equivalency'" do
+      expect(subject_instance.type).to eq('equivalency')
+    end
+  end
+
+  describe "valid?" do
+    let(:equivalency_id) { "00#{rand(100..999)}" }
+
+    it "in not valid when there is no equivalency_id" do
+      expect(subject_instance.valid?).to be_falsy
+    end
+
+    it "is valid if it has an equivalency_id" do
+      subject_instance.equivalency_id = equivalency_id
+      expect(subject_instance.valid?).to be_truthy
+    end
+
+    it "is not valid if the equivalency_id is not unique" do
+      other = described_class.create(equivalency_id: equivalency_id)
+      subject_instance.equivalency_id  = equivalency_id
+      expect(subject_instance.valid?).to be_falsy
+    end
+
+    it "is valid when the equivalency_id is unique" do
+      other = described_class.create(equivalency_id: equivalency_id)
+      subject_instance.equivalency_id  = equivalency_id.next
+      expect(subject_instance.valid?).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Add Equivalency resource. Has one to many relationship with Courses. Adjust seeds.rb and CoursesController#create to import equivalency data from json, when it is present

Some MeetingPatterns have no Location, so update seeds.rb and CoursesController#create to only try to add them when the data is present

We were running into some data errors because we were trying to persist objects that have already been created - Subjects in seeds.rb and Term and Campus in CoursesController#create - use find_or_create_by instead