### PR TITLE
Support Other Campus' Course Attributes

### DIFF
--- a/app/models/course_attribute.rb
+++ b/app/models/course_attribute.rb
@@ -2,7 +2,7 @@ class CourseAttribute < ::ActiveRecord::Base
   has_and_belongs_to_many :courses
 
   validates_presence_of :attribute_id, :family
-  validates_uniqueness_of :attribute_id
+  validates_uniqueness_of :attribute_id, scope: :family
 
   def type
     "attribute"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,10 +30,6 @@ end
   Term.create({strm: strm})
 end
 
-%w(AH BIOL HIS LITR MATH PHYS SOCS GP TS CIV DSJ ENV WI).each do |attribute_id|
-  CourseAttribute.create({attribute_id: attribute_id, family: "CLE"})
-end
-
 {"m" => "Monday", "t" => "Tuesday", "w" => "Wednesday", "th" => "Thursday", "f" => "Friday", "sa" => "Saturday", "su" => "Sunday"}.each do |abbreviation, name|
   Day.create(abbreviation: abbreviation, name: name)
 end
@@ -67,7 +63,7 @@ j["courses"].each do |course_json|
 
   @course = Course.create(course_attr)
 
-  attributes = course_json["cle_attributes"].map { |a| CourseAttribute.where(attribute_id: a["attribute_id"]).first }
+  attributes = course_json["cle_attributes"].map { |a| CourseAttribute.find_or_create_by(attribute_id: a["attribute_id"], family: a["family"]) }
   @course.course_attributes = attributes
 
   course_json["sections"].map do |section_json|

--- a/spec/models/course_attribute_spec.rb
+++ b/spec/models/course_attribute_spec.rb
@@ -12,15 +12,29 @@ RSpec.describe CourseAttribute do
   describe "valid?" do
     let(:valid_attributes) { {attribute_id: "PHYS", family: "CLE"} }
 
-    it "is valid if the attribute_id is unique" do
+    it "is valid if the attribute_id and family are unique" do
       expect(described_class.new(valid_attributes).valid?).to be_truthy
     end
 
-    it "is not valid if the attribute_id is not unique" do
+    it "is valid if the attribute_id is not unique but the family is" do
       described_class.new(valid_attributes).save
 
-      duplicate = described_class.new({attribute_id: valid_attributes[:attribute_id], family: "#{rand(3)}"})
-      expect(duplicate.valid?).to be_falsey
+      new_instance = described_class.new({attribute_id: valid_attributes[:attribute_id], family: "#{rand(3)}"})
+      expect(new_instance.valid?).to be_truthy
+    end
+
+    it "is valid if the attribute_id is unique but the family is not" do
+      described_class.new(valid_attributes).save
+
+      new_instance = described_class.new({attribute_id: "#{rand(3)}", family: valid_attributes[:family]})
+      expect(new_instance.valid?).to be_truthy
+    end
+
+    it "is not valid if the attribute_id and family are both duplicates" do
+      described_class.new(valid_attributes).save
+
+      new_instance = described_class.new(valid_attributes)
+      expect(new_instance.valid?).to be_falsey
     end
 
     it "is not valid if the attribute_id or family are blank" do


### PR DESCRIPTION
Crookston and Duluth have their own course attribute families, "GE" for Crookston and "DLE" for Duluth. They are mostly different than the CLE attributes but there is at least one overlap in the Duluth attribute ids. 

Change the CourseAttribute validation to require uniqueness of the family + attribute_id combination, rather than just attribute_id so these other attributes can be added. Adjust the seeds import to build the attributes as we get them from the export file.
