### PR TITLE
Conditionally display equivalency

### DIFF
--- a/app/views/courses/show.rabl
+++ b/app/views/courses/show.rabl
@@ -5,7 +5,7 @@ child :subject => :subject do
   attributes :type, :subject_id, :id, :description
 end
 
-child :equivalency => :equivalency do
+child :equivalency, if: ->(course) { course.equivalency.present? } do
   attributes :type, :equivalency_id
 end
 


### PR DESCRIPTION
Most courses do not have an equivalency. In these cases the "equivalency" json key is displaying with a value of null. Change the template to only show the node when there is an equivalency