### PR TITLE
Iw/caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ end
 gem 'rabl'
 gem 'oj'
 gem 'query_string_search'
+gem 'rack-cache'
 
 group :development, :test do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
     rabl (0.11.6)
       activesupport (>= 2.3.14)
     rack (1.6.0)
+    rack-cache (1.2)
+      rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.0)
@@ -167,6 +169,7 @@ DEPENDENCIES
   oj
   query_string_search
   rabl
+  rack-cache
   rails (= 4.2.0)
   rspec (~> 3.2)
   rspec-rails (~> 3.2)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -5,9 +5,7 @@ class CoursesController < ApplicationController
     campus = Campus.where(abbreviation: params[:campus_id].upcase).first
     term = Term.where(strm: params[:term_id]).first
 
-    courses = Course.for_campus_and_term(campus, term)
-
-    searchable_courses = SearchableCourses.new(courses)
+    searchable_courses = SearchableCourses.find(campus, term)
 
     query_string_search = params[:q]
     returned_courses = QueryStringSearch.new(searchable_courses, query_string_search).results

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,7 @@
 class CoursesController < ApplicationController
   def index
+    expires_in(8.hours, :public => true)
+
     Rails.logger.tagged("Ian") { Rails.logger.debug "######################New Request" }
 
     campus = Campus.where(abbreviation: params[:campus_id].upcase).first

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,6 +1,5 @@
 class CoursesController < ApplicationController
   def index
-    expires_in(8.hours, :public => true)
     Rails.logger.tagged("Ian") { Rails.logger.debug "######################New Request" }
 
     campus = Campus.where(abbreviation: params[:campus_id].upcase).first

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2,36 +2,23 @@ class CoursesController < ApplicationController
   def index
     expires_in(8.hours, :public => true)
 
-    Rails.logger.tagged("Ian") { Rails.logger.debug "######################New Request" }
-
     campus = Campus.where(abbreviation: params[:campus_id].upcase).first
     term = Term.where(strm: params[:term_id]).first
 
-    x = Time.now.to_i
-    Rails.logger.tagged("Ian") { Rails.logger.debug "Start course find" }
-    #courses = Course.for_campus_and_term(campus, term)
-    Rails.logger.tagged("Ian") { Rails.logger.debug "End course find: #{Time.now.to_i - x}" }
-
-    Rails.logger.tagged("Ian") { Rails.logger.debug "Start searchable course " }
     searchable_courses = SearchableCourses.find(campus, term)
-    Rails.logger.tagged("Ian") { Rails.logger.debug "End searchable course: #{Time.now.to_i - x} " }
 
-    Rails.logger.tagged("Ian") { Rails.logger.debug "Start filter course " }
     query_string_search = params[:q]
     returned_courses = QueryStringSearch.new(searchable_courses, query_string_search).results
-    Rails.logger.tagged("Ian") { Rails.logger.debug "End filter course: #{Time.now.to_i - x} " }
 
     @courses = CoursesPresenter.new
     @courses.campus = campus
     @courses.term = term
     @courses.courses = returned_courses
 
-    Rails.logger.tagged("Ian") { Rails.logger.debug "Start render course " }
     respond_to do |format|
       format.xml
       format.json
     end
-    Rails.logger.tagged("Ian") { Rails.logger.debug "Finish render course: #{Time.now.to_i - x} " }
   end
 
   def create

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -9,11 +9,11 @@ class CoursesController < ApplicationController
 
     x = Time.now.to_i
     Rails.logger.tagged("Ian") { Rails.logger.debug "Start course find" }
-    courses = Course.for_campus_and_term(campus, term)
+    #courses = Course.for_campus_and_term(campus, term)
     Rails.logger.tagged("Ian") { Rails.logger.debug "End course find: #{Time.now.to_i - x}" }
 
     Rails.logger.tagged("Ian") { Rails.logger.debug "Start searchable course " }
-    searchable_courses = SearchableCourses.new(courses)
+    searchable_courses = SearchableCourses.find(campus, term)
     Rails.logger.tagged("Ian") { Rails.logger.debug "End searchable course: #{Time.now.to_i - x} " }
 
     Rails.logger.tagged("Ian") { Rails.logger.debug "Start filter course " }

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,24 +1,36 @@
 class CoursesController < ApplicationController
   def index
     expires_in(8.hours, :public => true)
+    Rails.logger.tagged("Ian") { Rails.logger.debug "######################New Request" }
 
     campus = Campus.where(abbreviation: params[:campus_id].upcase).first
     term = Term.where(strm: params[:term_id]).first
 
-    searchable_courses = SearchableCourses.find(campus, term)
+    x = Time.now.to_i
+    Rails.logger.tagged("Ian") { Rails.logger.debug "Start course find" }
+    courses = Course.for_campus_and_term(campus, term)
+    Rails.logger.tagged("Ian") { Rails.logger.debug "End course find: #{Time.now.to_i - x}" }
 
+    Rails.logger.tagged("Ian") { Rails.logger.debug "Start searchable course " }
+    searchable_courses = SearchableCourses.new(courses)
+    Rails.logger.tagged("Ian") { Rails.logger.debug "End searchable course: #{Time.now.to_i - x} " }
+
+    Rails.logger.tagged("Ian") { Rails.logger.debug "Start filter course " }
     query_string_search = params[:q]
     returned_courses = QueryStringSearch.new(searchable_courses, query_string_search).results
+    Rails.logger.tagged("Ian") { Rails.logger.debug "End filter course: #{Time.now.to_i - x} " }
 
     @courses = CoursesPresenter.new
     @courses.campus = campus
     @courses.term = term
     @courses.courses = returned_courses
 
+    Rails.logger.tagged("Ian") { Rails.logger.debug "Start render course " }
     respond_to do |format|
       format.xml
       format.json
     end
+    Rails.logger.tagged("Ian") { Rails.logger.debug "Finish render course: #{Time.now.to_i - x} " }
   end
 
   def create

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,7 @@
 class CoursesController < ApplicationController
   def index
+    expires_in(8.hours, :public => true)
+
     campus = Campus.where(abbreviation: params[:campus_id].upcase).first
     term = Term.where(strm: params[:term_id]).first
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -5,7 +5,7 @@ class CoursesController < ApplicationController
     campus = Campus.where(abbreviation: params[:campus_id].upcase).first
     term = Term.where(strm: params[:term_id]).first
 
-    courses = Course.where(campus_id: campus.id, term_id: term.id)
+    courses = Course.for_campus_and_term(campus, term)
 
     searchable_courses = SearchableCourses.new(courses)
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -16,4 +16,10 @@ class Course < ::ActiveRecord::Base
   def cle_attributes
     course_attributes.where(family: "CLE")
   end
+
+  def self.for_campus_and_term(campus, term)
+    Rails.cache.fetch("#{campus.id}_#{term.id}", expires_in: 12.hours) do
+      self.where(campus_id: campus.id, term_id: term.id)
+    end
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -18,8 +18,8 @@ class Course < ::ActiveRecord::Base
   end
 
   def self.for_campus_and_term(campus, term)
-    Rails.cache.fetch("#{campus.id}_#{term.id}", expires_in: 12.hours) do
+    #Rails.cache.fetch("#{campus.id}_#{term.id}", expires_in: 12.hours) do
       self.where(campus_id: campus.id, term_id: term.id)
-    end
+    #end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -18,8 +18,6 @@ class Course < ::ActiveRecord::Base
   end
 
   def self.for_campus_and_term(campus, term)
-    #Rails.cache.fetch("#{campus.id}_#{term.id}", expires_in: 12.hours) do
-      self.where(campus_id: campus.id, term_id: term.id)
-    #end
+    self.where(campus_id: campus.id, term_id: term.id)
   end
 end

--- a/app/models/searchable_courses.rb
+++ b/app/models/searchable_courses.rb
@@ -23,6 +23,10 @@ class SearchableCourse < SimpleDelegator
     #end
   end
 
+  def cache_key
+    course.id
+  end
+
   def subject_id
     @subject ||= course.subject.subject_id
   end

--- a/app/models/searchable_courses.rb
+++ b/app/models/searchable_courses.rb
@@ -9,9 +9,10 @@ class SearchableCourses
   end
 
   def self.find(campus, term)
-    #Rails.cache.fetch("#{campus.id}_#{term.id}/searchable_courses", expires_in: 12.hours) do
-      self.new(Course.for_campus_and_term(campus, term))
-    #end
+    courses = Rails.cache.fetch("#{campus.id}_#{term.id}/all_courses", expires_in: 12.hours) do
+      Course.for_campus_and_term(campus, term).all
+    end
+    self.new(courses)
   end
 end
 

--- a/app/models/searchable_courses.rb
+++ b/app/models/searchable_courses.rb
@@ -17,6 +17,12 @@ end
 
 
 class SearchableCourse < SimpleDelegator
+  def initialize(course)
+    Rails.cache.fetch("#{course.id}/course", expires_in: 12.hours) do
+      super(course)
+    end
+  end
+
   def subject_id
     @subject ||= course.subject.subject_id
   end

--- a/app/models/searchable_courses.rb
+++ b/app/models/searchable_courses.rb
@@ -9,18 +9,18 @@ class SearchableCourses
   end
 
   def self.find(campus, term)
-    Rails.cache.fetch("#{campus.id}_#{term.id}/searchable_courses", expires_in: 12.hours) do
+    #Rails.cache.fetch("#{campus.id}_#{term.id}/searchable_courses", expires_in: 12.hours) do
       self.new(Course.for_campus_and_term(campus, term))
-    end
+    #end
   end
 end
 
 
 class SearchableCourse < SimpleDelegator
   def initialize(course)
-    Rails.cache.fetch("#{course.id}/course", expires_in: 12.hours) do
+    #Rails.cache.fetch("#{course.id}/course", expires_in: 12.hours) do
       super(course)
-    end
+    #end
   end
 
   def subject_id

--- a/app/models/searchable_courses.rb
+++ b/app/models/searchable_courses.rb
@@ -23,10 +23,6 @@ class SearchableCourse < SimpleDelegator
     #end
   end
 
-  def cache_key
-    course.id
-  end
-
   def subject_id
     @subject ||= course.subject.subject_id
   end

--- a/app/models/searchable_courses.rb
+++ b/app/models/searchable_courses.rb
@@ -7,6 +7,12 @@ class SearchableCourses
   def initialize(all_courses)
     self.all_courses = all_courses.map {|c| SearchableCourse.new(c) }
   end
+
+  def self.find(campus, term)
+    Rails.cache.fetch("#{campus.id}_#{term.id}/searchable_courses", expires_in: 12.hours) do
+      self.new(Course.for_campus_and_term(campus, term))
+    end
+  end
 end
 
 

--- a/app/models/searchable_courses.rb
+++ b/app/models/searchable_courses.rb
@@ -9,9 +9,16 @@ class SearchableCourses
   end
 
   def self.find(campus, term)
-    courses = Rails.cache.fetch("#{campus.id}_#{term.id}/all_courses", expires_in: 12.hours) do
-      Course.for_campus_and_term(campus, term).all
+    cached = Rails.cache.fetch("#{campus.id}_#{term.id}/all_courses")
+
+    unless cached
+      cached = Campus.where(campus_id: campus.id, term_id: term.id).all.load
+      Rails.cache.write(
+        "#{campus.id}_#{term.id}/all_courses",
+        cached
+      )
     end
+
     self.new(courses)
   end
 end

--- a/app/models/searchable_courses.rb
+++ b/app/models/searchable_courses.rb
@@ -26,9 +26,7 @@ end
 
 class SearchableCourse < SimpleDelegator
   def initialize(course)
-    #Rails.cache.fetch("#{course.id}/course", expires_in: 12.hours) do
-      super(course)
-    #end
+    super(course)
   end
 
   def subject_id

--- a/app/models/searchable_courses.rb
+++ b/app/models/searchable_courses.rb
@@ -12,14 +12,14 @@ class SearchableCourses
     cached = Rails.cache.fetch("#{campus.id}_#{term.id}/all_courses")
 
     unless cached
-      cached = Campus.where(campus_id: campus.id, term_id: term.id).all.load
+      cached = Course.where(campus_id: campus.id, term_id: term.id).all.load
       Rails.cache.write(
         "#{campus.id}_#{term.id}/all_courses",
         cached
       )
     end
 
-    self.new(courses)
+    self.new(cached)
   end
 end
 

--- a/app/models/searchable_courses.rb
+++ b/app/models/searchable_courses.rb
@@ -12,7 +12,7 @@ class SearchableCourses
     cached = Rails.cache.fetch("#{campus.id}_#{term.id}/all_courses")
 
     unless cached
-      cached = Course.where(campus_id: campus.id, term_id: term.id).all.load
+      cached = Course.includes(:subject, :course_attributes, :sections => [:instruction_mode]).where(campus_id: campus.id, term_id: term.id).all.load
       Rails.cache.write(
         "#{campus.id}_#{term.id}/all_courses",
         cached

--- a/app/views/attributes/show.rabl
+++ b/app/views/attributes/show.rabl
@@ -1,0 +1,4 @@
+object @attribute
+cache @attribute
+
+attributes :type, :attribute_id, :id, :family

--- a/app/views/campuses/show.rabl
+++ b/app/views/campuses/show.rabl
@@ -1,2 +1,3 @@
 object @campus
+cache @campus
 attributes :type, :abbreviation, :campus_id

--- a/app/views/combined_sections/show.rabl
+++ b/app/views/combined_sections/show.rabl
@@ -1,0 +1,4 @@
+object @combined_section
+cache @combined_section
+
+attributes :type, :catalog_number, :subject_id, :section_number

--- a/app/views/courses/show.rabl
+++ b/app/views/courses/show.rabl
@@ -1,5 +1,5 @@
 object @course
-cache @course
+
 attributes :type, :course_id, :id, :catalog_number, :description, :title
 
 child :subject => :subject do

--- a/app/views/courses/show.rabl
+++ b/app/views/courses/show.rabl
@@ -1,4 +1,5 @@
 object @course
+cache @course
 attributes :type, :course_id, :id, :catalog_number, :description, :title
 
 child :subject => :subject do

--- a/app/views/courses/show.rabl
+++ b/app/views/courses/show.rabl
@@ -3,7 +3,7 @@ object @course
 attributes :type, :course_id, :id, :catalog_number, :description, :title
 
 child :subject => :subject do
-  attributes :type, :subject_id, :id, :description
+  extends "subjects/show"
 end
 
 child :equivalency, if: ->(course) { course.equivalency.present? } do
@@ -17,37 +17,5 @@ end
 
 child :sections => :sections do
   collection attributes, :root => false, :object_root => false
-  attributes :type, :id, :class_number, :number, :component, :location, :credits_maximum, :credits_minimum, :notes
-
-  child :instruction_mode => :instruction_mode do
-    attributes :type, :instruction_mode_id, :id, :description
-  end
-
-  child :grading_basis => :grading_basis do
-    attributes :type, :grading_basis_id, :id, :description
-  end
-
-  child :instructors => :instructors do
-    collection attributes, :root => false, :object_root => false
-    attributes :type, :id, :name, :email, :role
-  end
-
-  child :meeting_patterns => :meeting_patterns do
-    collection attributes, :root => false, :object_root => false
-    attributes :type, :start_time, :end_time, :start_date, :end_date
-
-    child :location => :location do
-      attributes :type, :location_id, :id, :description
-    end
-
-    child :days => :days do
-      collection attributes, :root => false, :object_root => false
-      attributes :type, :name, :abbreviation
-    end
-  end
-
-  child :combined_sections => :combined_sections do
-    collection attributes, :root => false, :object_root => false
-    attributes :type, :catalog_number, :subject_id, :section_number
-  end
+  extends "sections/show"
 end

--- a/app/views/courses/show.rabl
+++ b/app/views/courses/show.rabl
@@ -1,4 +1,5 @@
 object @course
+cache @course
 
 attributes :type, :course_id, :id, :catalog_number, :description, :title
 
@@ -7,12 +8,12 @@ child :subject => :subject do
 end
 
 child :equivalency, if: ->(course) { course.equivalency.present? } do
-  attributes :type, :equivalency_id
+  extends "equivalencies/show"
 end
 
 child :cle_attributes => :cle_attributes do
   collection attributes, :root => false, :object_root => false
-  attributes :type, :attribute_id, :id, :family
+  extends "attributes/show"
 end
 
 child :sections => :sections do

--- a/app/views/days/show.rabl
+++ b/app/views/days/show.rabl
@@ -1,0 +1,4 @@
+object @day
+cache @day
+
+attributes :type, :name, :abbreviation

--- a/app/views/equivalencies/show.rabl
+++ b/app/views/equivalencies/show.rabl
@@ -1,0 +1,4 @@
+object @equivalency
+cache @equivalency
+
+attributes :type, :equivalency_id

--- a/app/views/grading_bases/show.rabl
+++ b/app/views/grading_bases/show.rabl
@@ -1,0 +1,3 @@
+object @grading_basis
+cache @grading_basis
+attributes :type, :grading_basis_id, :id, :description

--- a/app/views/instruction_modes/show.rabl
+++ b/app/views/instruction_modes/show.rabl
@@ -1,0 +1,4 @@
+object @instruction_mode
+cache @instruction_mode
+
+attributes :type, :instruction_mode_id, :id, :description

--- a/app/views/instructors/show.rabl
+++ b/app/views/instructors/show.rabl
@@ -1,0 +1,3 @@
+object @instructor
+cache @instructor
+attributes :type, :id, :name, :email, :role

--- a/app/views/locations/show.rabl
+++ b/app/views/locations/show.rabl
@@ -1,0 +1,4 @@
+object @location
+cache @location
+
+attributes :type, :location_id, :id, :description

--- a/app/views/meeting_patterns/show.rabl
+++ b/app/views/meeting_patterns/show.rabl
@@ -1,0 +1,13 @@
+object @meeting_pattern
+cache @meeting_pattern
+
+attributes :type, :start_time, :end_time, :start_date, :end_date
+
+child :location => :location do
+  extends "locations/show"
+end
+
+child :days => :days do
+  collection attributes, :root => false, :object_root => false
+  extends "days/show"
+end

--- a/app/views/sections/show.rabl
+++ b/app/views/sections/show.rabl
@@ -8,7 +8,7 @@ child :instruction_mode => :instruction_mode do
 end
 
 child :grading_basis => :grading_basis do
-  extends "instruction_modes/show"
+  extends "grading_bases/show"
 end
 
 child :instructors => :instructors do
@@ -18,19 +18,10 @@ end
 
 child :meeting_patterns => :meeting_patterns do
   collection attributes, :root => false, :object_root => false
-  attributes :type, :start_time, :end_time, :start_date, :end_date
-
-  child :location => :location do
-    attributes :type, :location_id, :id, :description
-  end
-
-  child :days => :days do
-    collection attributes, :root => false, :object_root => false
-    attributes :type, :name, :abbreviation
-  end
+  extends "meeting_patterns/show"
 end
 
 child :combined_sections => :combined_sections do
   collection attributes, :root => false, :object_root => false
-  attributes :type, :catalog_number, :subject_id, :section_number
+  extends "combined_sections/show"
 end

--- a/app/views/sections/show.rabl
+++ b/app/views/sections/show.rabl
@@ -1,0 +1,36 @@
+object @sections
+cache @sections
+
+attributes :type, :id, :class_number, :number, :component, :location, :credits_maximum, :credits_minimum, :notes
+
+child :instruction_mode => :instruction_mode do
+  attributes :type, :instruction_mode_id, :id, :description
+end
+
+child :grading_basis => :grading_basis do
+  attributes :type, :grading_basis_id, :id, :description
+end
+
+child :instructors => :instructors do
+  collection attributes, :root => false, :object_root => false
+  attributes :type, :id, :name, :email, :role
+end
+
+child :meeting_patterns => :meeting_patterns do
+  collection attributes, :root => false, :object_root => false
+  attributes :type, :start_time, :end_time, :start_date, :end_date
+
+  child :location => :location do
+    attributes :type, :location_id, :id, :description
+  end
+
+  child :days => :days do
+    collection attributes, :root => false, :object_root => false
+    attributes :type, :name, :abbreviation
+  end
+end
+
+child :combined_sections => :combined_sections do
+  collection attributes, :root => false, :object_root => false
+  attributes :type, :catalog_number, :subject_id, :section_number
+end

--- a/app/views/sections/show.rabl
+++ b/app/views/sections/show.rabl
@@ -4,16 +4,16 @@ cache @sections
 attributes :type, :id, :class_number, :number, :component, :location, :credits_maximum, :credits_minimum, :notes
 
 child :instruction_mode => :instruction_mode do
-  attributes :type, :instruction_mode_id, :id, :description
+  extends "instruction_modes/show"
 end
 
 child :grading_basis => :grading_basis do
-  attributes :type, :grading_basis_id, :id, :description
+  extends "instruction_modes/show"
 end
 
 child :instructors => :instructors do
   collection attributes, :root => false, :object_root => false
-  attributes :type, :id, :name, :email, :role
+  extends "instructors/show"
 end
 
 child :meeting_patterns => :meeting_patterns do

--- a/app/views/subjects/show.rabl
+++ b/app/views/subjects/show.rabl
@@ -1,0 +1,4 @@
+object @subject
+cache @subject
+
+attributes :type, :subject_id, :id, :description

--- a/app/views/terms/show.rabl
+++ b/app/views/terms/show.rabl
@@ -1,2 +1,3 @@
 object @term
+cache @term
 attributes :type, :term_id, :strm

--- a/bin/rails
+++ b/bin/rails
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
-end
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
-end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/config.ru
+++ b/config.ru
@@ -1,9 +1,9 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
-require 'rack/cache'
-use Rack::Cache,
-  :verbose     => true,
-  :metastore   => 'file:tmp/cache/rack/meta',
-  :entitystore => 'file:tmp/cache/rack/body'
+#require 'rack/cache'
+#use Rack::Cache,
+  #:verbose     => true,
+  #:metastore   => 'file:tmp/cache/rack/meta',
+  #:entitystore => 'file:tmp/cache/rack/body'
 run Rails.application

--- a/config.ru
+++ b/config.ru
@@ -1,9 +1,9 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
-#require 'rack/cache'
-#use Rack::Cache,
-  #:verbose     => true,
-  #:metastore   => 'file:tmp/cache/rack/meta',
-  #:entitystore => 'file:tmp/cache/rack/body'
+require 'rack/cache'
+use Rack::Cache,
+  :verbose     => true,
+  :metastore   => 'file:tmp/cache/rack/meta',
+  :entitystore => 'file:tmp/cache/rack/body'
 run Rails.application

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,9 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
+require 'rack/cache'
+use Rack::Cache,
+  :verbose     => true,
+  :metastore   => 'file:tmp/cache/rack/meta',
+  :entitystore => 'file:tmp/cache/rack/body'
 run Rails.application

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+   config.cache_store = :memory_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
   # Add `rack-cache` to your Gemfile before enabling this.
   # For large-scale production use, consider using a caching reverse proxy like
   # NGINX, varnish or squid.
-  # config.action_dispatch.rack_cache = true
+   config.action_dispatch.rack_cache = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
   # Add `rack-cache` to your Gemfile before enabling this.
   # For large-scale production use, consider using a caching reverse proxy like
   # NGINX, varnish or squid.
-   config.action_dispatch.rack_cache = true
+   #config.action_dispatch.rack_cache = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+   config.cache_store = :memory_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
   # Add `rack-cache` to your Gemfile before enabling this.
   # For large-scale production use, consider using a caching reverse proxy like
   # NGINX, varnish or squid.
-  # config.action_dispatch.rack_cache = true
+   config.action_dispatch.rack_cache = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-   config.cache_store = :memory_store
+   config.cache_store = :file_store, "tmp/file_cache"
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
Commit history here isn't the best. Basically I tried a lot of caching ideas, decided that they weren't working right and then went back to first principles by removing all the caching and then trying again.

Final result is that we have a few different types of caching:

### Rack Cache

rack-cache handles requests that we've seen before (current cache setting is 8 hours). If there's a cache hit, the request never even gets as far as Rails. The fastest caching. But also the most limited. A URL has to match exactly for the cache to match.

### Rabl Caching

This uses the Rails cache, which is currently set to a file-based cache. I have all of the resources using their own templates and each of them is cached. So, for example if a request generates the rabl template for the Monday day resource, that output is now cached and the cache will be used for all future appearances of Monday.

If we run a query to show all courses for a campus, all of the templates we need to handle all future requests for that campus are now cached.

In an un-cached query, the RABL templates were as slow, if not slower, than the Active Record side of things. So having templates cached helps a lot.

### Query Caching

This also uses the Rails cache. The query that return all courses for a campus/term now caches the results of that query. The code I'm [using here](https://github.com/umn-asr/courses/commit/a512a6c3cf26f005bc1ff5764bf909176e4774f9?diff=split) could be improved, but it does work.

## What's still not great

CLE attributes aren't being cached correctly. I think it might be because CLE attributes have a many-to-many relationship, but I'm not sure. If you try to find all WI classes in umntc, for example, the request takes 20 seconds, regardless of what else has been cached.

That said, if people want to search just for CLE stuff, they can use our CLE service. And there are ways to make CLE searches faster in this service. The trick is to put any CLE criteria at the end of the query string:

- http://courses-staging.umn.edu/campuses/umntc/terms/1149/courses.json?q=subject_id=HIST,cle_attribute_id=WI

Takes 4.7 seconds

- http://courses-staging.umn.edu/campuses/umntc/terms/1149/courses.json?q=cle_attribute_id=WI,subject_id=HIST

Takes 22.3 seconds

The data set is filtered through the search criteria in order. So if you put the CLE one first, we check the entire data set for CLE. But if you put it 2nd, you're only checking the courses that already matched the HIST filter. Basically, the fewer records you search for CLE data the faster it goes.