### PR TITLE
Associate Subject with Campus and Term

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -3,7 +3,7 @@ class CoursesController < ApplicationController
     campus = Campus.where(abbreviation: params[:campus_id].upcase).first
     term = Term.where(strm: params[:term_id]).first
 
-    courses = Course.where(campus_id: campus.id, term_id: term.id)
+    courses = Course.for_campus_and_term(campus, term)
 
     searchable_courses = SearchableCourses.new(courses)
 

--- a/app/models/campus.rb
+++ b/app/models/campus.rb
@@ -1,7 +1,7 @@
 class Campus < ::ActiveRecord::Base
 
-  has_many :subject, dependent: :destroy
-  has_many :courses, through: :subject, dependent: :destroy
+  has_many :subjects, dependent: :destroy
+  has_many :courses, through: :subjects, dependent: :destroy
 
   validates_presence_of :abbreviation
   validates_uniqueness_of :abbreviation

--- a/app/models/campus.rb
+++ b/app/models/campus.rb
@@ -1,8 +1,11 @@
 class Campus < ::ActiveRecord::Base
+
+  has_many :subject, dependent: :destroy
+  has_many :courses, through: :subject, dependent: :destroy
+
   validates_presence_of :abbreviation
   validates_uniqueness_of :abbreviation
 
-  has_many :courses, dependent: :destroy
 
   def type
     "campus"

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,13 +1,13 @@
 class Course < ::ActiveRecord::Base
-  belongs_to :term
-  belongs_to :campus
   belongs_to :subject
   belongs_to :equivalency
   has_and_belongs_to_many :course_attributes
   has_many :sections
 
-  validates_presence_of :term_id, :campus_id, :course_id
-  validates_uniqueness_of :course_id, scope: [:term_id, :campus_id]
+  delegate :term, :campus, to: :subject
+
+  validates_presence_of :subject_id, :course_id
+  validates_uniqueness_of :course_id, scope: [:subject_id]
 
   def type
     "course"

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -9,6 +9,8 @@ class Course < ::ActiveRecord::Base
   validates_presence_of :subject_id, :course_id
   validates_uniqueness_of :course_id, scope: [:subject_id]
 
+  scope :for_campus_and_term, ->(campus, term) { joins(:subject).where(subjects: { campus_id: campus.id, term_id: term.id }) }
+
   def type
     "course"
   end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,5 +1,7 @@
 class Subject < ::ActiveRecord::Base
-  has_many :courses
+  belongs_to :term
+  belongs_to :campus
+  has_many :courses, dependent: :destroy
 
   validates_presence_of :subject_id, :description
   validates_uniqueness_of :subject_id

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -3,8 +3,8 @@ class Subject < ::ActiveRecord::Base
   belongs_to :campus
   has_many :courses, dependent: :destroy
 
-  validates_presence_of :subject_id, :description
-  validates_uniqueness_of :subject_id
+  validates_presence_of :subject_id, :description, :campus_id, :term_id
+  validates_uniqueness_of :subject_id, scope: [:campus, :term]
 
   def type
     "subject"

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -1,7 +1,7 @@
 class Term < ::ActiveRecord::Base
 
   has_many :subjects, dependent: :destroy
-  has_many :courses, through: :subject, dependent: :destroy
+  has_many :courses, through: :subjects, dependent: :destroy
 
   validates_presence_of :strm
   validates_uniqueness_of :strm

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -1,5 +1,7 @@
 class Term < ::ActiveRecord::Base
-  has_many :courses, dependent: :destroy
+
+  has_many :subjects, dependent: :destroy
+  has_many :courses, through: :subject, dependent: :destroy
 
   validates_presence_of :strm
   validates_uniqueness_of :strm

--- a/db/migrate/20150408205348_add_campus_id_and_term_id_to_subjects.rb
+++ b/db/migrate/20150408205348_add_campus_id_and_term_id_to_subjects.rb
@@ -1,0 +1,8 @@
+class AddCampusIdAndTermIdToSubjects < ActiveRecord::Migration
+  def change
+    add_reference :subjects, :campus, index: true
+    add_foreign_key :subjects, :campuses
+    add_reference :subjects, :term, index: true
+    add_foreign_key :subjects, :terms
+  end
+end

--- a/db/migrate/20150408205701_remove_campus_id_and_term_id_from_courses.rb
+++ b/db/migrate/20150408205701_remove_campus_id_and_term_id_from_courses.rb
@@ -1,0 +1,8 @@
+class RemoveCampusIdAndTermIdFromCourses < ActiveRecord::Migration
+  def change
+    remove_reference :courses, :campus, index: true
+    remove_foreign_key :courses, :campuses
+    remove_reference :courses, :term, index: true
+    remove_foreign_key :courses, :terms
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150323151217) do
+ActiveRecord::Schema.define(version: 20150408205701) do
 
   create_table "campuses", force: :cascade do |t|
     t.string "abbreviation"
@@ -40,8 +40,6 @@ ActiveRecord::Schema.define(version: 20150323151217) do
   add_index "course_attributes_courses", ["course_id"], name: "index_course_attributes_courses_on_course_id"
 
   create_table "courses", force: :cascade do |t|
-    t.integer "campus_id"
-    t.integer "term_id"
     t.string  "course_id"
     t.string  "title"
     t.string  "description"
@@ -50,10 +48,8 @@ ActiveRecord::Schema.define(version: 20150323151217) do
     t.integer "equivalency_id"
   end
 
-  add_index "courses", ["campus_id"], name: "index_courses_on_campus_id"
   add_index "courses", ["equivalency_id"], name: "index_courses_on_equivalency_id"
   add_index "courses", ["subject_id"], name: "index_courses_on_subject_id"
-  add_index "courses", ["term_id"], name: "index_courses_on_term_id"
 
   create_table "days", force: :cascade do |t|
     t.string "name"
@@ -131,9 +127,14 @@ ActiveRecord::Schema.define(version: 20150323151217) do
   add_index "sections", ["course_id"], name: "index_sections_on_course_id"
 
   create_table "subjects", force: :cascade do |t|
-    t.string "subject_id"
-    t.string "description"
+    t.string  "subject_id"
+    t.string  "description"
+    t.integer "campus_id"
+    t.integer "term_id"
   end
+
+  add_index "subjects", ["campus_id"], name: "index_subjects_on_campus_id"
+  add_index "subjects", ["term_id"], name: "index_subjects_on_term_id"
 
   create_table "terms", force: :cascade do |t|
     t.string "strm"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,10 +47,8 @@ j["courses"].each do |course_json|
   course_attr = course_json.slice("title", "description", "course_id", "catalog_number")
 
   campus = Campus.where(abbreviation: j["campus"]["abbreviation"]).first
-  # course_attr[:campus_id] = campus.id
 
   term = Term.where(strm: j["term"]["strm"]).first
-  # course_attr[:term_id] = term.id
 
   subject = Subject.find_or_create_by(course_json["subject"].slice("subject_id", "description").merge({campus_id: campus.id, term_id: term.id}))
   course_attr[:subject_id] = subject.id

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,12 +47,12 @@ j["courses"].each do |course_json|
   course_attr = course_json.slice("title", "description", "course_id", "catalog_number")
 
   campus = Campus.where(abbreviation: j["campus"]["abbreviation"]).first
-  course_attr[:campus_id] = campus.id
+  # course_attr[:campus_id] = campus.id
 
   term = Term.where(strm: j["term"]["strm"]).first
-  course_attr[:term_id] = term.id
+  # course_attr[:term_id] = term.id
 
-  subject = Subject.find_or_create_by(course_json["subject"].slice("subject_id", "description"))
+  subject = Subject.find_or_create_by(course_json["subject"].slice("subject_id", "description").merge({campus_id: campus.id, term_id: term.id}))
   course_attr[:subject_id] = subject.id
 
   equivalency_json = course_json["equivalency"]

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Course do
                   }
 
     it "returns courses that match the supplied campus and term" do
-      # expect(Course.for_campus_and_term(campus, term)).to eq(courses)
+      expect(Course.for_campus_and_term(campus, term)).to eq(courses)
     end
     context "when there are no matches"
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -10,21 +10,21 @@ RSpec.describe Course do
   end
 
   describe "valid?" do
-    it "is valid if the campus_id, term_id, and course_id are unique" do
-      expect(described_class.new(campus_id: "UMNRC", term_id: "1159", course_id: "002066").valid?).to be_truthy
+    it "is valid if the subject_id and course_id are unique" do
+      expect(described_class.new(subject_id: rand(1..999_999), course_id: "002066").valid?).to be_truthy
     end
 
-    it "is not valid if the combination of campus_id, term_id, and course_id are not unique" do
-      described_class.new(campus_id: "UMNRC", term_id: "1159", course_id: "002066").save
+    it "is not valid if the combination of subject_id and course_id are not unique" do
+      duplicate_subject_id = rand(1..999_999)
+      described_class.new(subject_id: duplicate_subject_id, course_id: "002066").save
 
-      duplicate = described_class.new(campus_id: "UMNRC", term_id: "1159", course_id: "002066")
+      duplicate = described_class.new(subject_id: duplicate_subject_id, course_id: "002066")
       expect(duplicate.valid?).to be_falsey
     end
 
-    it "is not valid if the campus_id, term_id, or course_id are blank" do
-      expect(described_class.new(campus_id: "", term_id: "1159", course_id: "002066").valid?).to be_falsey
-      expect(described_class.new(campus_id: "UMNRC", term_id: "", course_id: "002066").valid?).to be_falsey
-      expect(described_class.new(campus_id: "UMNRC", term_id: "1159", course_id: "").valid?).to be_falsey
+    it "is not valid if the subject_id or course_id is blank" do
+      expect(described_class.new(subject_id: "", course_id: "002066").valid?).to be_falsey
+      expect(described_class.new(subject_id: rand(1..999_999), course_id: "").valid?).to be_falsey
     end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3,6 +3,29 @@ require "rails_helper"
 RSpec.describe Course do
   let(:course_instance) { described_class.new }
 
+  describe ".for_campus_and_term" do
+    let(:campus)  { Campus.create(abbreviation: "UMNTEST") }
+    let(:term)    { Term.create(strm: "2259") }
+    let(:subject) { campus.subjects.where(term_id: term.id).create(subject_id: "TEST", description: "for testing") }
+    let(:courses) {
+                      3.times do
+                        subject.courses.create(course_id: rand(1000..9999).to_s)
+                      end
+                  }
+
+    it "returns courses that match the supplied campus and term" do
+      # expect(Course.for_campus_and_term(campus, term)).to eq(courses)
+    end
+    context "when there are no matches"
+
+      it "returns an empty collection"
+    context "when the campus matches but the term does not"
+      it "does not return the course"
+    context "when the term matches but the campus does not"
+      it "does not return the course"
+
+  end
+
   describe "type" do
     it "is 'course'" do
       expect(course_instance.type).to eq("course")

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe Course do
   describe ".for_campus_and_term" do
     let(:campus)  { Campus.create(abbreviation: "UMNTEST") }
     let(:term)    { Term.create(strm: "2259") }
-    let(:subject) { campus.subjects.where(term_id: term.id).create(subject_id: "TEST", description: "for testing") }
+    let(:subject) { Subject.create(subject_id: "TEST", description: "for testing", campus_id: campus.id, term_id: term.id) }
     let(:courses) {
                       3.times do
                         subject.courses.create(course_id: rand(1000..9999).to_s)
                       end
+
+                      subject.courses
                   }
 
     it "returns courses that match the supplied campus and term" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -14,18 +14,29 @@ RSpec.describe Course do
 
                       subject.courses
                   }
+    let(:other_campus) { Campus.create(abbreviation: "UMNOTHER") }
+    let(:other_term)   { Term.create(strm: "3359" ) }
+
+    it "returns a collection" do
+      expect(Course.for_campus_and_term(campus, term)).to respond_to(:each)
+    end
 
     it "returns courses that match the supplied campus and term" do
+      other_subject = Subject.create(subject_id: "TEST", description: "different campus term", campus_id: other_campus.id, term_id: other_term.id)
+      other_course = other_subject.courses.create(course_id: rand(1000..9999).to_s)
       expect(Course.for_campus_and_term(campus, term)).to eq(courses)
+      expect(Course.for_campus_and_term(campus, term)).to_not include(other_course)
     end
-    context "when there are no matches"
+    it "returns an empty collection when there are no matches" do
+      expect(Course.for_campus_and_term(other_campus, other_term)).to be_empty
+    end
+    it "does not return the course when the campus matches but the term does not" do
+      expect(Course.for_campus_and_term(campus, other_term)).to be_empty
+    end
 
-      it "returns an empty collection"
-    context "when the campus matches but the term does not"
-      it "does not return the course"
-    context "when the term matches but the campus does not"
-      it "does not return the course"
-
+    it "does not return the course when the term matches but the campus does not" do
+      expect(Course.for_campus_and_term(other_campus, term)).to be_empty
+    end
   end
 
   describe "type" do

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -10,21 +10,28 @@ RSpec.describe Subject do
   end
 
   describe "valid?" do
-    let(:valid_attributes) { {subject_id: "PHYS", description: "Physics"}}
+    let(:valid_attributes) { {subject_id: "PHYS", description: "Physics", campus_id: rand(1..500), term_id: rand(1..500)}}
 
-    it "is valid if the subject_id is unique" do
-      expect(described_class.new(valid_attributes).valid?).to be_truthy
+    it "is valid if the subject_id is unique for a campus and term" do
+      base_subject = described_class.create(valid_attributes)
+      new_subject_id = described_class.new(valid_attributes.merge({ subject_id: "CSCI" }))
+      new_campus_id = described_class.new(valid_attributes.merge({ campus_id: rand(1000..2000)}))
+      new_term_id = described_class.new(valid_attributes.merge({ term_id: rand(1000..2000)}))
+      expect(base_subject.valid?).to be_truthy
+      expect(new_subject_id.valid?).to be_truthy
+      expect(new_campus_id.valid?).to be_truthy
+      expect(new_term_id.valid?).to be_truthy
     end
 
-    it "is not valid if the subject_id is not unique" do
+    it "is not valid if the subject_id is not unique for a campus and term" do
       described_class.new(valid_attributes).save
 
-      duplicate = described_class.new({subject_id: valid_attributes[:subject_id], description: "#{rand(3)}"})
+      duplicate = described_class.new({subject_id: valid_attributes[:subject_id], description: "#{rand(3)}", campus_id: valid_attributes[:campus_id], term_id: valid_attributes[:term_id]})
       expect(duplicate.valid?).to be_falsey
     end
 
-    it "is not valid if the subject_id or description are blank" do
-      [:subject_id, :description].each do |required_attr|
+    it "is not valid if the subject_id, description, campus_id, or term_id are blank" do
+      [:subject_id, :description, :campus_id, :term_id].each do |required_attr|
         invalid_attributes = valid_attributes.dup
         invalid_attributes.delete(required_attr)
         expect(described_class.new(invalid_attributes).valid?).to be_falsey

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,8 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
+  config.use_transactional_fixtures = true
+
 end
 
 def compare_element_to_documentation(element)


### PR DESCRIPTION
Change the association of campus and term from Course to Subject. Subjects vary from campus to campus, so JOUR in the Twin Cities can be different than JOUR in Duluth. This was causing subject to be nil when there was near but not quite subject matches from campus to campus. (See Issue #45).

Change subject to be campus and term specific to address this. This also allows us to redo that data model so that course no longer directly needs the term and campus association. Most of these changes are directly related to that change as well as adding a scope to course so the CoursesController can still fetch the appropriate courses for the term and campus. 

Indirectly related changes include redoing some validations (f0cc5cb, c907800).

In an unrelated change, changed the rspec configuration to clear out the db between tests. Because we  added a scope to fetch the courses, testing it involved the database and those tests require the database to be cleared out.