### PR TITLE
Increase caching time to 2 days

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,6 +1,6 @@
 class CoursesController < ApplicationController
   def index
-    expires_in(8.hours, :public => true)
+    expires_in(48.hours, :public => true)
 
     campus = Campus.where(abbreviation: params[:campus_id].upcase).first
     term = Term.where(strm: params[:term_id]).first

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-   config.cache_store = :memory_store
+   config.cache_store = :file_store, "tmp/file_cache", { expires_in: 48.hours }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-   config.cache_store = :file_store, "tmp/file_cache"
+   config.cache_store = :file_store, "tmp/file_cache", { expires_in: 48.hours }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
Fixes issue #46

The import of data takes a long time (currently several hours). So our
plan is to rely on the cached data until we complete importing the new
data.

To support this, I'm greatly increasing the caching time to 48 hours.
Two days is more than we need, since we plan on importing new data once
a day. But I want to make sure that the cache will last until we
invalidate it after the import.