### PR TITLE
Allow all campuses to do Lib Ed/Gen Ed searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,31 +87,36 @@ Find courses with a catalog number in a range of values:
 
 Returns all courses with a catalog_number greater than or equal to 1000 and less than 5000
 
-### Liberal Education
+### Liberal Education / General Education
 
-Get courses that are Writing Intensive
+Different campuses have different ways of identifying courses that meet General Education or Liberal Education criteria. You can search for these by using the `course_attribute_family`:
 
-`courses.json?q=cle_attribute_id=WI`
+- UMNTC's Liberal Education: `courses.json?q=course_attribute_family=CLE`
+- UMNDL's Liberal Education: `courses.json?q=course_attribute_family=DLE`
+- UMNRO's Liberal Education: `courses.json?q=course_attribute_family=GE`
+- UMNMO's General Education: `courses.json?q=course_attribute_family=GER`
 
----
+And if you're looking for a courses with a specific attribute, you can search with `course_attribute_id`
 
-Get courses that meet Civic Life or Historical Perspectives
+Get courses that satisfy UMNTC's Writing Intensive
 
-`courses.xml?q=cle_attribute_id=HIS|CIV`
+`courses.json?q=course_attribute_id=WI`
 
----
+Get courses that satisfy UMNRO's Mathematical Thinking
 
-Get courses that have any CLE attribute
+`courses.json?q=course_attribute_id=MATH%20THINK`
 
-`courses.xml?q=cle_attribute_id=all`
+Get courses that meet either UMNDL's Fine Arts or Humanities
 
-Or that have no CLE attribute
+`courses.xml?q=course_attribute_id=FINE%20ARTS|HUMANITIES
 
-`courses.xml?q=cle_attribute_id=none`
+Get courses that have any attribute
 
----
+`courses.xml?q=course_attribute_id=all`
 
-**Note**: Liberal Education data is currently only correct for UMNTC. We know about this bug and will be fixing it soon.
+Or that have no attirbute
+
+`courses.xml?q=course_attribute_id=none`
 
 ### Instruction Mode
 
@@ -148,7 +153,7 @@ or
 
 Any of the searches can be combined. For example
 
-`courses.json?q=cle_attribute_id=WI,instruction_mode_id=P,catalog_number>=2000,catalog_number<3000,subject_id=HIST`
+`courses.json?q=course_attribute_id=WI,instruction_mode_id=P,catalog_number>=2000,catalog_number<3000,subject_id=HIST`
 
 Will return any courses that are:
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -14,8 +14,4 @@ class Course < ::ActiveRecord::Base
   def type
     "course"
   end
-
-  def self.for_campus_and_term(campus, term)
-    self.where(campus_id: campus.id, term_id: term.id)
-  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -15,8 +15,7 @@ class Course < ::ActiveRecord::Base
     "course"
   end
 
-  def cle_attributes
-    course_attributes.where(family: "CLE")
+  def self.for_campus_and_term(campus, term)
+    self.where(campus_id: campus.id, term_id: term.id)
   end
-
 end

--- a/app/models/searchable_courses.rb
+++ b/app/models/searchable_courses.rb
@@ -33,10 +33,13 @@ class SearchableCourse < SimpleDelegator
     @subject ||= course.subject.subject_id
   end
 
-  def cle_attribute_id
-    @cle_attributes ||= (course.cle_attributes.collect { |a| a.attribute_id }).to_set
+  def course_attribute_family
+    @course_attribute_families ||= (course.course_attributes.collect { |a| a.family }).to_set
   end
 
+  def course_attribute_id
+    @course_attribute_ids ||= (course.course_attributes.collect { |a| a.attribute_id }).to_set
+  end
 
   def instruction_mode_id
     @instruction_modes ||= (course.sections.collect { |s| s.instruction_mode.instruction_mode_id}).to_set

--- a/app/views/courses/show.rabl
+++ b/app/views/courses/show.rabl
@@ -11,7 +11,7 @@ child :equivalency, if: ->(course) { course.equivalency.present? } do
   extends "equivalencies/show"
 end
 
-child :cle_attributes => :cle_attributes do
+child :course_attributes => :course_attributes do
   collection attributes, :root => false, :object_root => false
   extends "attributes/show"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -61,7 +61,7 @@ j["courses"].each do |course_json|
 
   @course = Course.create(course_attr)
 
-  attributes = course_json["cle_attributes"].map { |a| CourseAttribute.find_or_create_by(attribute_id: a["attribute_id"], family: a["family"]) }
+  attributes = course_json["course_attributes"].map { |a| CourseAttribute.find_or_create_by(attribute_id: a["attribute_id"], family: a["family"]) }
   @course.course_attributes = attributes
 
   course_json["sections"].map do |section_json|

--- a/doc/resources/course.yml
+++ b/doc/resources/course.yml
@@ -19,7 +19,7 @@ course:
         description: "The course's title"
       subject:
         type: resource
-      cle_attributes:
+      course_attributes:
         type: collection
       sections:
         type: collection

--- a/spec/requests/search_courses_spec.rb
+++ b/spec/requests/search_courses_spec.rb
@@ -77,27 +77,41 @@ RSpec.describe "search courses" do
     end
   end
 
-  describe "by cle attribute id" do
-    it "returns only courses that match the cle attribute" do
-      get "/campuses/UMNTC/terms/1149/courses.json?q=cle_attribute_id=WI"
+  describe "by course attribute family" do
+    it "returns only courses that match the course attribute" do
+      get "/campuses/UMNTC/terms/1149/courses.json?q=course_attribute_family=CLE"
       courses = JSON.parse(response.body)["courses"]
 
       expect(courses).not_to be_empty
 
       courses.each do |course|
-        matching_attributes = course["cle_attributes"].select { |a| a["attribute_id"] == "WI" }
+        matching_attributes = course["course_attributes"].select { |a| a["family"] == "CLE" }
+        expect(matching_attributes).not_to be_empty
+      end
+    end
+  end
+
+  describe "by course attribute id" do
+    it "returns only courses that match the course attribute" do
+      get "/campuses/UMNTC/terms/1149/courses.json?q=course_attribute_id=WI"
+      courses = JSON.parse(response.body)["courses"]
+
+      expect(courses).not_to be_empty
+
+      courses.each do |course|
+        matching_attributes = course["course_attributes"].select { |a| a["attribute_id"] == "WI" }
         expect(matching_attributes).not_to be_empty
       end
     end
 
-    it "returns only courses that match the cle attribute" do
-      get "/campuses/UMNTC/terms/1149/courses.json?q=cle_attribute_id=PHYS%7CHIS"
+    it "returns only courses that match the course attribute" do
+      get "/campuses/UMNTC/terms/1149/courses.json?q=course_attribute_id=PHYS%7CHIS"
       courses = JSON.parse(response.body)["courses"]
 
       expect(courses).not_to be_empty
 
       courses.each do |course|
-        matching_attributes = course["cle_attributes"].select { |a| %w(PHYS HIS).include?(a["attribute_id"]) }
+        matching_attributes = course["course_attributes"].select { |a| %w(PHYS HIS).include?(a["attribute_id"]) }
         expect(matching_attributes).not_to be_empty
       end
     end
@@ -133,19 +147,19 @@ RSpec.describe "search courses" do
 
   describe "combining searches" do
     it "returns courses that match all criteria" do
-      get "/campuses/UMNTC/terms/1149/courses.json?q=subject_id=AFRO,catalog_number>3000,catalog_number<4000,cle_attribute_id=GP,instruction_mode_id=P"
+      get "/campuses/UMNTC/terms/1149/courses.json?q=subject_id=AFRO,catalog_number>3000,catalog_number<4000,course_attribute_id=GP,instruction_mode_id=P"
       courses = JSON.parse(response.body)["courses"]
 
       expect(courses).not_to be_empty
 
       course = courses.sample
-      cle_attributes = course["cle_attributes"].collect { |a| a["attribute_id"] }
+      course_attributes = course["course_attributes"].collect { |a| a["attribute_id"] }
       instruction_modes = course["sections"].collect { |s| s["instruction_mode"]["instruction_mode_id"] }
 
       expect(course["subject"]["subject_id"]).to eq("AFRO")
       expect(course["catalog_number"].to_i).to be > 3000
       expect(course["catalog_number"].to_i).to be < 4000
-      expect(cle_attributes).to include("GP")
+      expect(course_attributes).to include("GP")
       expect(instruction_modes).to include("P")
     end
   end

--- a/test/fixtures/courses_example.json
+++ b/test/fixtures/courses_example.json
@@ -21,7 +21,7 @@
         "subject_id": "PHYS",
         "description": "Physics"
       },
-      "cle_attributes": [
+      "course_attributes": [
         {
           "type": "attribute",
           "attribute_id": "WI",
@@ -589,7 +589,7 @@
         "type": "equivalency",
         "equivalency_id": "00788"
       },
-      "cle_attributes": [
+      "course_attributes": [
         {
           "type": "attribute",
           "attribute_id": "HIS",


### PR DESCRIPTION
Fixes #38 

'CLE' as a family of course attributes only applies to UMNTC campuses. Duluth, Rochester, and Morris each have their own attribute family for these Lib Ed/Gen Ed classes (Crookston, as far as I can tell, has no such attribute).

Previous implementation only allowed for searching and displaying attributes that were CLE. So other campuses had nothing. This PR:

- Removes the UMNTC-specific terminology
- Adds the ability to search by course_attribute_family
- Renames cle_attribute_id search criteria to course_attribute_id
- Documents & tests the attribute searching changes

This PR will also require the data importing code to use the node name `course_attributes` instead of `cle_attributes`. I've told @davinlagerroos about this change.