### PR TITLE
Use rack-cors to set access headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'rabl'
 gem 'oj'
 gem 'query_string_search'
 gem 'rack-cache'
+gem 'rack-cors', :require => 'rack/cors'
 
 group :development, :test do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
     rack (1.6.0)
     rack-cache (1.2)
       rack (>= 0.4)
+    rack-cors (0.3.1)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.0)
@@ -170,6 +171,7 @@ DEPENDENCIES
   query_string_search
   rabl
   rack-cache
+  rack-cors
   rails (= 4.2.0)
   rspec (~> 3.2)
   rspec-rails (~> 3.2)

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,16 @@ module CourseGuide
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.middleware.insert_before 0, "Rack::Cors", :debug => true, :logger => (-> { Rails.logger }) do
+      allow do
+        origins '*'
+
+        resource '*',
+          :headers => :any,
+          :methods => [:get],
+          :max_age => 0
+      end
+    end
   end
 end


### PR DESCRIPTION
Using rack-cors to allow the API to be used by sites on other domains.
Setup is currently pretty simple, allow all GET requests.

Fixes #52 