### PR TITLE
Remove unnecessary RABL caching.

### DIFF
--- a/app/views/attributes/show.rabl
+++ b/app/views/attributes/show.rabl
@@ -1,4 +1,3 @@
 object @attribute
-cache @attribute
 
 attributes :type, :attribute_id, :id, :family

--- a/app/views/combined_sections/show.rabl
+++ b/app/views/combined_sections/show.rabl
@@ -1,4 +1,3 @@
 object @combined_section
-cache @combined_section
 
 attributes :type, :catalog_number, :subject_id, :section_number

--- a/app/views/days/show.rabl
+++ b/app/views/days/show.rabl
@@ -1,4 +1,3 @@
 object @day
-cache @day
 
 attributes :type, :name, :abbreviation

--- a/app/views/equivalencies/show.rabl
+++ b/app/views/equivalencies/show.rabl
@@ -1,4 +1,3 @@
 object @equivalency
-cache @equivalency
 
 attributes :type, :equivalency_id

--- a/app/views/grading_bases/show.rabl
+++ b/app/views/grading_bases/show.rabl
@@ -1,3 +1,2 @@
 object @grading_basis
-cache @grading_basis
 attributes :type, :grading_basis_id, :id, :description

--- a/app/views/instruction_modes/show.rabl
+++ b/app/views/instruction_modes/show.rabl
@@ -1,4 +1,3 @@
 object @instruction_mode
-cache @instruction_mode
 
 attributes :type, :instruction_mode_id, :id, :description

--- a/app/views/instructors/show.rabl
+++ b/app/views/instructors/show.rabl
@@ -1,3 +1,2 @@
 object @instructor
-cache @instructor
 attributes :type, :id, :name, :email, :role

--- a/app/views/locations/show.rabl
+++ b/app/views/locations/show.rabl
@@ -1,4 +1,3 @@
 object @location
-cache @location
 
 attributes :type, :location_id, :id, :description

--- a/app/views/meeting_patterns/show.rabl
+++ b/app/views/meeting_patterns/show.rabl
@@ -1,5 +1,4 @@
 object @meeting_pattern
-cache @meeting_pattern
 
 attributes :type, :start_time, :end_time, :start_date, :end_date
 

--- a/app/views/sections/show.rabl
+++ b/app/views/sections/show.rabl
@@ -1,5 +1,4 @@
 object @sections
-cache @sections
 
 attributes :type, :id, :class_number, :number, :component, :location, :credits_maximum, :credits_minimum, :notes
 

--- a/app/views/subjects/show.rabl
+++ b/app/views/subjects/show.rabl
@@ -1,4 +1,3 @@
 object @subject
-cache @subject
 
 attributes :type, :subject_id, :id, :description


### PR DESCRIPTION
I thought that caching each resource was necessary, but it's currently
not.

We only display the sub-resources of Course as part of a course. And
Rabl currently caches all of the sub-resources as part of Course, thanks
to the cache command in the /courses/show.rabl view.

Removing the caching of the sub-resources has no effect on performance.
It does have the nice effect of making our Redis store a lot smaller.