### PR TITLE
Add Cache Rebuild and Rotation

### DIFF
--- a/app/models/campus.rb
+++ b/app/models/campus.rb
@@ -6,8 +6,8 @@ class Campus < ::ActiveRecord::Base
   validates_presence_of :abbreviation
   validates_uniqueness_of :abbreviation
 
-  def self.fetch(campus_id)
-    Rails.cache.fetch(cache_key_for_instance(campus_id)) do
+  def self.fetch(campus_id, cache = Rails.cache)
+    cache.fetch(cache_key_for_instance(campus_id)) do
       Campus.where(abbreviation: campus_id.upcase).first
     end
   end

--- a/app/models/presenters/course_presenter.rb
+++ b/app/models/presenters/course_presenter.rb
@@ -15,8 +15,8 @@ class CoursePresenter
     course.cache_key
   end
 
-  def self.fetch(course)
-    Rails.cache.fetch(course.cache_key) do
+  def self.fetch(course, cache = Rails.cache)
+    cache.fetch(course.cache_key) do
       self.new(Course.find(course.id))
     end
   end

--- a/app/models/presenters/courses_presenter.rb
+++ b/app/models/presenters/courses_presenter.rb
@@ -1,12 +1,12 @@
 class CoursesPresenter
   attr_accessor :campus, :term, :courses
 
-  def self.fetch(campus, term, courses)
+  def self.fetch(campus, term, courses, cache = Rails.cache)
     presented_courses = self.new
     presented_courses.campus = campus
     presented_courses.term = term
 
-    presented_courses.courses = courses.map { |course| CoursePresenter.fetch(course) }
+    presented_courses.courses = courses.map { |course| CoursePresenter.fetch(course, cache) }
     presented_courses
   end
 end

--- a/app/models/queryable_course.rb
+++ b/app/models/queryable_course.rb
@@ -1,11 +1,11 @@
 class QueryableCourse
   attr_accessor :course, :subject_id, :catalog_number, :course_attribute_family, :course_attribute_id, :instruction_mode_id, :locations
 
-  def self.read(key)
-    Rails.cache.read(key)
+  def self.read(key, cache = Rails.cache)
+    cache.read(key)
   end
 
-  def self.build(full_course)
+  def self.build(full_course, cache = Rails.cache)
     x = self.new
     x.course = OpenStruct.new(cache_key: full_course.cache_key, id: full_course.id)
     x.subject_id = full_course.subject.subject_id
@@ -14,7 +14,7 @@ class QueryableCourse
     x.course_attribute_id = (full_course.course_attributes.collect { |a| a.attribute_id }).to_set
     x.instruction_mode_id = (full_course.sections.collect { |s| s.instruction_mode.instruction_mode_id}).to_set
     x.locations = (full_course.sections.collect { |s| s.location}).to_set
-    Rails.cache.fetch(x.cache_key) { x }
+    cache.fetch(x.cache_key) { x }
     x
   end
 

--- a/app/models/queryable_courses.rb
+++ b/app/models/queryable_courses.rb
@@ -12,7 +12,7 @@ class QueryableCourses
       end
 
       cache.write(cache_key(campus, term), queryable_cache_keys)
-      fetch(campus, term)
+      fetch(campus, term, cache)
     end
   end
 

--- a/app/models/queryable_courses.rb
+++ b/app/models/queryable_courses.rb
@@ -1,7 +1,7 @@
 class QueryableCourses
-  def self.fetch(campus, term)
-    if Rails.cache.exist?(cache_key(campus, term))
-      Rails.cache.read(cache_key(campus,term)).map do |key|
+  def self.fetch(campus, term, cache = Rails.cache)
+    if cache.exist?(cache_key(campus, term))
+      cache.read(cache_key(campus,term)).map do |key|
         QueryableCourse.read(key)
       end
     else
@@ -11,7 +11,7 @@ class QueryableCourses
         queryable_cache_keys << QueryableCourse.build(course).cache_key
       end
 
-      Rails.cache.write(cache_key(campus, term), queryable_cache_keys)
+      cache.write(cache_key(campus, term), queryable_cache_keys)
       fetch(campus, term)
     end
   end

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -6,8 +6,8 @@ class Term < ::ActiveRecord::Base
   validates_presence_of :strm
   validates_uniqueness_of :strm
 
-  def self.fetch(term_id)
-    Rails.cache.fetch(cache_key_for_instance(term_id)) do
+  def self.fetch(term_id, cache = Rails.cache)
+    cache.fetch(cache_key_for_instance(term_id)) do
       Term.where(strm: term_id.upcase).first
     end
   end

--- a/app/services/cache_warmer.rb
+++ b/app/services/cache_warmer.rb
@@ -31,7 +31,7 @@ class CacheWarmer
 
   def cache_full_courses
     campuses_and_terms.each do |campus, term|
-      Course.for_campus_and_term(campus, term).map { |course| CoursePresenter.fetch(course, cache) }
+      Course.for_campus_and_term(campus, term).each { |course| CoursePresenter.fetch(course, cache) }
     end
   end
 

--- a/app/services/cache_warmer.rb
+++ b/app/services/cache_warmer.rb
@@ -1,0 +1,49 @@
+class CacheWarmer
+  def self.warm(cache)
+    new(cache).warm
+  end
+
+  def initialize(cache)
+    self.cache = cache
+  end
+
+  def warm
+    cache_terms
+    cache_campuses
+    cache_queryable_courses
+    cache_full_courses
+  end
+
+  private
+  attr_accessor :cache
+
+  def cache_terms
+    terms.each { |term| Term.fetch(term.strm, cache)}
+  end
+
+  def cache_campuses
+    campuses.each { |campus| Campus.fetch(campus.abbreviation, cache) }
+  end
+
+  def cache_queryable_courses
+    campuses_and_terms.each { |campus, term| QueryableCourses.fetch(campus, term, cache) }
+  end
+
+  def cache_full_courses
+    campuses_and_terms.each do |campus, term|
+      Course.for_campus_and_term(campus, term).map { |course| CoursePresenter.fetch(course, cache) }
+    end
+  end
+
+  def campuses_and_terms
+    campuses.product(terms)
+  end
+
+  def terms
+    Term.all
+  end
+
+  def campuses
+    Campus.all
+  end
+end

--- a/app/services/rack_cache_manager.rb
+++ b/app/services/rack_cache_manager.rb
@@ -1,0 +1,39 @@
+class RackCacheManager
+  include Rails.application.routes.url_helpers
+
+  def self.reset
+    manager = new
+    manager.clear
+    manager.warm
+  end
+
+  def clear
+    cache_folders.each do |folder|
+      FileUtils.rm_rf(folder)
+    end
+  end
+
+  def warm(urls=base_urls_to_cache)
+    urls.each do |url|
+      `curl #{url}`
+    end
+  end
+
+  private
+  def cache_folders
+    ["#{Rails.root}/tmp/cache/rack/meta", "#{Rails.root}/tmp/cache/rack/body"]
+  end
+
+  def base_urls_to_cache
+    campuses = Campus.all
+    terms    = Term.all
+    formats  = [:xml, :json]
+
+    campuses.product(terms).inject([]) do |array, (campus, term)|
+      array << campus_term_courses_url(campus.abbreviation, term.strm, format: :xml)
+      array << campus_term_courses_url(campus.abbreviation, term.strm, format: :json)
+      array
+    end
+  end
+
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module CourseGuide
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
 
-    config.autoload_paths += %W(#{Rails.root}/app/models/presenters #{Rails.root}/lib)
+    config.autoload_paths += %W(#{Rails.root}/app/models/presenters #{Rails.root}/app/services #{Rails.root}/lib)
 
     config.middleware.insert_before 0, "Rack::Cors", :debug => true, :logger => (-> { Rails.logger }) do
       allow do

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module CourseGuide
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
 
-    config.autoload_paths += %W(#{Rails.root}/app/models/presenters)
+    config.autoload_paths += %W(#{Rails.root}/app/models/presenters #{Rails.root}/lib)
 
     config.middleware.insert_before 0, "Rack::Cors", :debug => true, :logger => (-> { Rails.logger }) do
       allow do

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-   config.cache_store = :redis_store, 'redis://localhost:6379/0/cache', { expires_in: 48.hours }
+   config.cache_store = CachePool.instance.current
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-   config.cache_store = :redis_store, 'redis://localhost:6379/0/cache', { expires_in: 48.hours }
+  config.cache_store = CACHE_POOL.current
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  config.cache_store = CACHE_POOL.current
+  config.cache_store = CachePool.instance.current
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,4 +42,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  routes.default_url_options[:host]="http://localhost"
+  routes.default_url_options[:port]="3000"
 end

--- a/config/initializers/cache_pool.rb
+++ b/config/initializers/cache_pool.rb
@@ -1,0 +1,1 @@
+CACHE_POOL = CachePool.new(7)

--- a/config/initializers/cache_pool.rb
+++ b/config/initializers/cache_pool.rb
@@ -1,1 +1,0 @@
-CACHE_POOL = CachePool.new(7)

--- a/lib/cache_pool.rb
+++ b/lib/cache_pool.rb
@@ -1,7 +1,9 @@
 class CachePool
-  def initialize(pool_size, redis_configuration = {})
-    self.pool_size            = pool_size
-    self.redis_configuration  = redis_configuration
+  include Singleton
+
+  def initialize
+    self.pool_size            = 7
+    self.redis_configuration  = {}
     build_pool
   end
 

--- a/lib/cache_pool.rb
+++ b/lib/cache_pool.rb
@@ -28,7 +28,7 @@ class CachePool
 
   def build_pool
     1.upto(pool_size).each do |i|
-      pool << ActiveSupport::Cache.lookup_store(:redis_store, redis_configuration.merge(db: i))
+      pool << ActiveSupport::Cache.lookup_store(:redis_store, redis_configuration.merge(db: i, expires_in: 48.hours))
     end
   end
 

--- a/lib/cache_pool.rb
+++ b/lib/cache_pool.rb
@@ -1,0 +1,60 @@
+class CachePool
+  def initialize(pool_size, redis_configuration = {})
+    self.pool_size            = pool_size
+    self.redis_configuration  = redis_configuration
+    build_pool
+  end
+
+  def current
+    pool[current_index]
+  end
+
+  def next
+    pool[next_index]
+  end
+
+  def next!
+    index.set('current_cache_db', next_db)
+  end
+
+  private
+  attr_accessor :pool_size, :redis_configuration
+
+  def pool
+    @pool ||= []
+  end
+
+  def build_pool
+    1.upto(pool_size).each do |i|
+      pool << ActiveSupport::Cache.lookup_store(:redis_store, redis_configuration.merge(db: i))
+    end
+  end
+
+  def index
+    @index ||= Redis.new(redis_configuration.merge(db: 0))
+  end
+
+  def current_db
+    if index.get('current_cache_db')
+      index.get('current_cache_db').to_i
+    else
+      1
+    end
+  end
+
+  def next_db
+    (current_db % pool_size) + 1
+  end
+
+  def current_index
+    index_for(current_db)
+  end
+
+  def next_index
+    index_for(next_db)
+  end
+
+  def index_for(db)
+    db - 1
+  end
+end

--- a/lib/tasks/json_import.rake
+++ b/lib/tasks/json_import.rake
@@ -4,6 +4,8 @@ namespace :json_import do
     CacheWarmer.warm(CachePool.instance.next)
     CachePool.instance.next!
     `touch #{Rails.root}/tmp/restart.txt`
+    sleep 1
+    RackCacheManager.reset
   end
 
   desc "imports class json files from the supplied directory "

--- a/lib/tasks/json_import.rake
+++ b/lib/tasks/json_import.rake
@@ -4,7 +4,6 @@ namespace :json_import do
     args.with_defaults(:directory => 'tmp', :file_pattern => "classes_for_*.json")
     json_files = Rake::FileList[File.join(args[:directory], args[:file_pattern])]
 
-    # ActiveRecord::Base.subclasses.each(&:delete_all)
     Course.delete_all
     Subject.delete_all
     CourseAttribute.delete_all

--- a/lib/tasks/json_import.rake
+++ b/lib/tasks/json_import.rake
@@ -1,4 +1,11 @@
 namespace :json_import do
+  desc "imports json files and updates the cache"
+  task :update_all, [:directory, :file_pattern] => :directory_import do |t, args|
+    CacheWarmer.warm(CachePool.instance.next)
+    CachePool.instance.next!
+    `touch #{Rails.root}/tmp/restart.txt`
+  end
+
   desc "imports class json files from the supplied directory "
   task :directory_import, [:directory, :file_pattern] => :environment do |t, args|
     args.with_defaults(:directory => 'tmp', :file_pattern => "classes_for_*.json")

--- a/spec/lib/cache_pool_spec.rb
+++ b/spec/lib/cache_pool_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe CachePool do
 
   let(:index)       { Redis.new }
-  let(:pool_size)   { rand(3..9) }
+  let(:pool_size)   { 7 }
 
-  subject { described_class.new(pool_size) }
+  subject { described_class.instance }
 
   describe "current" do
     it "returns the same cache when called multiple times" do
@@ -23,7 +23,7 @@ RSpec.describe CachePool do
       end
     end
 
-    context "when the current_cache_db is set is redis" do
+    context "when the current_cache_db is set in redis" do
       let(:cache_number) { rand(1..pool_size) }
 
       before do

--- a/spec/lib/cache_pool_spec.rb
+++ b/spec/lib/cache_pool_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe CachePool do
+
+  let(:index)       { Redis.new }
+  let(:pool_size)   { rand(3..9) }
+
+  subject { described_class.new(pool_size) }
+
+  describe "current" do
+    it "returns the same cache when called multiple times" do
+      expect(subject.current).to eq(subject.current)
+    end
+
+    context "when current_cache_db is not set in redis" do
+      before do
+        index.del('current_cache_db')
+      end
+
+      it "is the cache store for redis db 1" do
+        expect(subject.current).to respond_to(:fetch)
+        expect(subject.current.options[:db]).to eq(1)
+      end
+    end
+
+    context "when the current_cache_db is set is redis" do
+      let(:cache_number) { rand(1..pool_size) }
+
+      before do
+        index.set('current_cache_db', cache_number)
+      end
+
+      after do
+        index.flushdb
+      end
+
+      it "is cache store for the current_cache_db" do
+        expect(subject.current.options[:db]).to eq(cache_number)
+      end
+    end
+  end
+
+  describe "next" do
+    it "returns the same cache when called multiple times" do
+      expect(subject.current).to eq(subject.current)
+    end
+
+    it "is the cache store for the current db + 1" do
+      current_db = subject.current.options[:db]
+      expect(subject.next.options[:db]).to eq(current_db + 1)
+    end
+
+    context "when the current db is equal to the pool size" do
+      before do
+        index.set('current_cache_db', pool_size)
+      end
+
+      it "is the cache store for redis db 1" do
+        expect(subject.next.options[:db]).to eq(1)
+      end
+    end
+  end
+
+  describe "next!" do
+    it "makes the next store the current store" do
+      old_next = subject.next
+      subject.next!
+      expect(subject.current).to eq(old_next)
+    end
+  end
+end

--- a/spec/lib/cache_pool_spec.rb
+++ b/spec/lib/cache_pool_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe CachePool do
       expect(subject.current).to eq(subject.current)
     end
 
+    it "has an expiration of 48 hours" do
+      expect(subject.current.options[:expires_in]).to eq(48.hours)
+    end
+
     context "when current_cache_db is not set in redis" do
       before do
         index.del('current_cache_db')

--- a/spec/services/cache_warmer_spec.rb
+++ b/spec/services/cache_warmer_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe CacheWarmer do
+  let(:cache)   { instance_double("ActiveSupport::Cache::Store") }
+  subject       { described_class.new(cache) }
+
+  describe ".warm" do
+    it "instantiates a new CacheWarmer with the supplied cache and calls #warm on it" do
+      cache_warmer = instance_double(described_class)
+      expect(described_class).to receive(:new).with(cache).and_return(cache_warmer)
+      expect(cache_warmer).to receive(:warm)
+
+      described_class.warm(cache)
+    end
+
+  end
+
+  describe "warm" do
+    let(:terms)     { generate_terms }
+    let(:campuses)  { generate_campuses }
+
+    before do
+      allow(Campus).to            receive(:all).and_return(campuses)
+      allow(Term).to              receive(:all).and_return(terms)
+      allow(Campus).to            receive(:fetch)
+      allow(Term).to              receive(:fetch)
+      allow(QueryableCourses).to  receive(:fetch)
+    end
+
+    it "caches all terms with its cache" do
+      terms.each do |term|
+        expect(Term).to receive(:fetch).with(term.strm, cache)
+      end
+      subject.warm
+    end
+
+    it "caches all campuses" do
+      campuses.each do |campus|
+        expect(Campus).to receive(:fetch).with(campus.abbreviation, cache)
+      end
+      subject.warm
+    end
+
+    it "caches the queryable version of all courses for each campus and term" do
+      campuses.product(terms).each do |campus, term|
+        expect(QueryableCourses).to receive(:fetch).with(campus, term, cache)
+      end
+
+      subject.warm
+    end
+
+    it "caches the full version of the all the courses for each campus and term" do
+      campuses.product(terms).each do |campus, term|
+        courses = generate_courses
+        allow(Course).to receive(:for_campus_and_term).with(campus, term).and_return(courses)
+        courses.each do |course|
+          expect(CoursePresenter).to receive(:fetch).with(course, cache)
+        end
+      end
+
+      subject.warm
+    end
+  end
+
+  def generate_terms
+    this_year = Time.now.strftime('%y').to_i
+    years = (this_year..99).take(rand(3..6))
+    years.flat_map { |year| ["1#{year}3", "1#{year}5", "1#{year}9"] }.map { |strm| Term.new(strm: strm)}
+  end
+
+  def generate_campuses
+    campus_abbreviations = ["UMNCR", "UMNDL", "UMNMO", "UMNRO", "UMNTC"].take(rand(2..5))
+    campus_abbreviations.map { |campus_abbreviation| Campus.new(abbreviation: campus_abbreviation)}
+  end
+
+  def generate_courses
+    rand(5..10).times.map { Course.new(course_id: rand(11_111..99_999).to_s) }
+  end
+end

--- a/spec/services/rack_cache_manager_spec.rb
+++ b/spec/services/rack_cache_manager_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe RackCacheManager do
+  include Rails.application.routes.url_helpers
+
+  subject { described_class.new }
+
+  describe ".reset" do
+    it "builds a new RackCacheManager, then calls clear and warm" do
+      instance = instance_double(described_class)
+      expect(RackCacheManager).to receive(:new).and_return(instance)
+      expect(instance).to receive(:clear)
+      expect(instance).to receive(:warm)
+      RackCacheManager.reset
+    end
+  end
+
+  describe "#clear" do
+    before do
+      `mkdir -p #{Rails.root}/tmp/cache/rack/body/te`
+      `touch #{Rails.root}/tmp/cache/rack/body/te/a-cache-file`
+      `mkdir -p #{Rails.root}/tmp/cache/rack/meta/st`
+      `touch #{Rails.root}/tmp/cache/rack/meta/st/a-cache-file`
+    end
+
+    after do
+      `rm -rf #{Rails.root}/tmp/cache/rack/*`
+    end
+
+    it "removes files from the file cache directories" do
+      cache_dir = Dir.new("#{Rails.root}/tmp/cache/rack")
+
+      expect(cache_dir.entries).to include("body", "meta")
+      subject.clear
+      expect(cache_dir.entries).not_to include("body", "meta")
+    end
+  end
+
+  describe "warm" do
+    context "a collection of urls is supplied" do
+      let(:urls_to_cache) {
+                              [
+                                "https://my_server/my_route/1/to_cache.json",
+                                "https://my_server/my_route/1/to_cache.xml",
+                                "https://my_server/my_route/2/to_cache.json"
+                              ]
+                          }
+      it "requests the supplied urls" do
+        urls_to_cache.each do |url|
+          expect(subject).to receive(:`).with("curl #{url}")
+        end
+        subject.warm(urls_to_cache)
+      end
+    end
+
+    context "nothing is supplied" do
+      it "requests courses.json and courses.xml for each campus/term combination" do
+        campus_abbreviations  = ["UMNCR", "UMNDL", "UMNMO", "UMNRO", "UMNTC"].take(rand(2..5))
+        strms                 = ((Time.now.year-2000)..99).take(3).flat_map { |year| ["1#{year}3", "1#{year}5", "1#{year}9"] }
+
+        allow(Campus).to receive(:all).and_return(campus_abbreviations.map { |abbr| Campus.new(abbreviation: abbr) } )
+        allow(Term).to receive(:all).and_return(strms.map { |strm| Term.new(strm: strm) })
+
+        campus_abbreviations.product(strms).each do |(abbr,strm)|
+          expect(subject).to receive(:`).with("curl #{campus_term_courses_url(abbr, strm, format: :xml)}")
+          expect(subject).to receive(:`).with("curl #{campus_term_courses_url(abbr, strm, format: :json)}")
+        end
+        subject.warm
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Once the json file import completes we need to update our cache with the new information. However, we rely heavily on caching for performance so we do not want to just wipe the cache and have user requests potentially hitting active record while the cache rebuilds. Because a redis instance supports multiple databases, the app can run off the current database while we cache model information into a cache backed by a different database. 

The CachePool singleton handles keeping track of the redis cache stores so we can put the new data into the "next" cache. CachePool also has a next! method that makes the rebuilt database the current one in the pool. The rebuild is handled by CacheWarmer which knows the objects that need caching. For this to work the models and presenters needed to have their fetch methods updated so the new cache could be passed as a dependency. All of them have the current rails cache as the default, so if no cache is passed the method will work as normal

We also need to refresh the rack url cache. RachCacheManager provides a wrapper around these tasks.

All this is scripted by a rake task json_import:update_all, which has the directory_import task as a dependency.