### PR TITLE
Json Formatting Fixes

### DIFF
--- a/app/models/presenters/meeting_pattern_presenter.rb
+++ b/app/models/presenters/meeting_pattern_presenter.rb
@@ -1,6 +1,6 @@
 class MeetingPatternPresenter
   extend Forwardable
-  def_delegators :meeting_pattern, :type, :start_time, :end_time, :start_date, :end_date
+  def_delegators :meeting_pattern, :type, :start_time, :end_time
 
   attr_accessor :location, :meeting_pattern, :days
 
@@ -13,4 +13,18 @@ class MeetingPatternPresenter
   def cache_key
     "#{meeting_pattern.type}_#{meeting_pattern.id}"
   end
+
+  def start_date
+    date_format(meeting_pattern.start_date)
+  end
+
+  def end_date
+    date_format(meeting_pattern.end_date)
+  end
+
+  private
+  def date_format(date)
+    date.strftime('%Y-%m-%d')
+  end
+
 end

--- a/app/views/sections/show.rabl
+++ b/app/views/sections/show.rabl
@@ -1,7 +1,7 @@
 object @sections
 cache @sections
 
-attributes :type, :id, :class_number, :number, :component, :location, :credits_maximum, :credits_minimum, :notes
+attributes :type, :id, :class_number, :number, :component, :location, :credits_minimum, :credits_maximum, :notes
 
 child :instruction_mode => :instruction_mode do
   extends "instruction_modes/show"

--- a/spec/models/presenters/meeting_pattern_presenter_spec.rb
+++ b/spec/models/presenters/meeting_pattern_presenter_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe MeetingPatternPresenter do
+  let(:meeting_pattern) { MeetingPattern.new }
+
+  subject { described_class.new(meeting_pattern) }
+
+  describe "start_date" do
+    it "is the meeting pattern start_date formatted as yyyy-mm-dd" do
+      start_date = Time.now
+      meeting_pattern.start_date = start_date
+      expect(subject.start_date).to eq(start_date.strftime('%Y-%m-%d'))
+    end
+
+    it "pads single month and date numbers with 0s" do
+      meeting_pattern.start_date = Time.new(Time.now.year, 1, 1)
+      expect(subject.start_date).to eq("#{Time.now.year}-01-01")
+    end
+  end
+
+  describe "end_date" do
+    it "is the meeting pattern end_date formatted as yyyy-mm-dd" do
+      end_date = Time.now
+      meeting_pattern.end_date = end_date
+      expect(subject.end_date).to eq(end_date.strftime('%Y-%m-%d'))
+    end
+
+    it "pads single month and date numbers with 0s" do
+      meeting_pattern.end_date = Time.new(Time.now.year, 1, 1)
+      expect(subject.end_date).to eq("#{Time.now.year}-01-01")
+    end
+  end
+end


### PR DESCRIPTION
A couple of updates to our output format to make it match the sample json:
  1. Dates should be returned in a yyyy-mm-dd format. We were returning them in a date/time format. Right now, this only effects MeetingPatterns, so this pull request gives this knowledge to MeetingPatternPresenter. If we have other dates, this should get extracted into something else  
  2. In sections, credits minimum should appear before credits maximum