### PR TITLE
Simplify caching of QueryableCourse(s)

### DIFF
--- a/app/models/queryable_course.rb
+++ b/app/models/queryable_course.rb
@@ -1,24 +1,13 @@
 class QueryableCourse
   attr_accessor :course, :subject_id, :catalog_number, :course_attribute_family, :course_attribute_id, :instruction_mode_id, :locations
 
-  def self.read(key, cache = Rails.cache)
-    cache.read(key)
-  end
-
-  def self.build(full_course, cache = Rails.cache)
-    x = self.new
-    x.course = OpenStruct.new(id: full_course.id)
-    x.subject_id = full_course.subject.subject_id
-    x.catalog_number = full_course.catalog_number
-    x.course_attribute_family = (full_course.course_attributes.collect { |a| a.family }).to_set
-    x.course_attribute_id = (full_course.course_attributes.collect { |a| a.attribute_id }).to_set
-    x.instruction_mode_id = (full_course.sections.collect { |s| s.instruction_mode.instruction_mode_id}).to_set
-    x.locations = (full_course.sections.collect { |s| s.location}).to_set
-    cache.fetch(x.cache_key) { x }
-    x
-  end
-
-  def cache_key
-    "#{course.id}_queryable"
+  def initialize(full_course)
+    self.course = OpenStruct.new(id: full_course.id)
+    self.subject_id = full_course.subject.subject_id
+    self.catalog_number = full_course.catalog_number
+    self.course_attribute_family = (full_course.course_attributes.collect { |a| a.family }).to_set
+    self.course_attribute_id = (full_course.course_attributes.collect { |a| a.attribute_id }).to_set
+    self.instruction_mode_id = (full_course.sections.collect { |s| s.instruction_mode.instruction_mode_id}).to_set
+    self.locations = (full_course.sections.collect { |s| s.location}).to_set
   end
 end

--- a/app/models/queryable_courses.rb
+++ b/app/models/queryable_courses.rb
@@ -1,18 +1,9 @@
 class QueryableCourses
   def self.fetch(campus, term, cache = Rails.cache)
-    if cache.exist?(cache_key(campus, term))
-      cache.read(cache_key(campus,term)).map do |key|
-        QueryableCourse.read(key)
-      end
-    else
-      queryable_cache_keys = []
-
+    cache.fetch(cache_key(campus, term)) do
       Course.for_campus_and_term(campus, term).collect do |course|
-        queryable_cache_keys << QueryableCourse.build(course).cache_key
+        QueryableCourse.new(course)
       end
-
-      cache.write(cache_key(campus, term), queryable_cache_keys)
-      fetch(campus, term, cache)
     end
   end
 


### PR DESCRIPTION
For some reason I made this more complex than it needs to be. I was
caching each queryable course individually, and then caching a
collection of all the queryable course ids. So reading them out of the
cache required two steps:

1. Retrieve the keys
2. Retrieve a queryable course for each key

I was probably doing this because of either a speed concern or because
of the idea that small cache entries are better than big cache entries.

But the speed of this approach is equivalent to just have one big cache
entry of queryable_courses. And since we always retrieve a collection of
queryable_courses, we might as well cache them as a collection. Also, it
makes the code way easier to parse.