### PR TITLE
Add MemoryCache, use it for QueryableCourses

### DIFF
--- a/app/models/queryable_courses.rb
+++ b/app/models/queryable_courses.rb
@@ -1,8 +1,10 @@
 class QueryableCourses
-  def self.fetch(campus, term, cache = Rails.cache)
-    cache.fetch(cache_key(campus, term)) do
-      Course.for_campus_and_term(campus, term).collect do |course|
-        QueryableCourse.new(course)
+  def self.fetch(campus, term, rails_cache = Rails.cache)
+    MemoryCache.fetch(cache_key(campus, term)) do
+      rails_cache.fetch(cache_key(campus, term)) do
+        Course.for_campus_and_term(campus, term).collect do |course|
+          QueryableCourse.new(course)
+        end
       end
     end
   end

--- a/config/initializers/memory_cache.rb
+++ b/config/initializers/memory_cache.rb
@@ -1,0 +1,18 @@
+module Caching
+  class MemoryCache
+      include Singleton
+
+      # create a private instance of MemoryStore
+      def initialize
+        @memory_store = ActiveSupport::Cache::MemoryStore.new
+      end
+
+      # this will allow our MemoryCache to be called just like Rails.cache
+      # every method passed to it will be passed to our MemoryStore
+      def method_missing(m, *args, &block)
+        @memory_store.send(m, *args, &block)
+      end
+  end
+end
+
+MemoryCache = Caching::MemoryCache.instance


### PR DESCRIPTION
Every request requires the server to pull all QueryableCourses out of
the cache. This can be slow for big campuses, since that set can be up
to 8000 items big.

So to make this part of the request as fast as possible, we can put
QueryableCourses into a memory cache. Retrieval out of Memory is much,
much faster.

But Memory caching has a drawback, every time we restart the passenger
process the cache is is cleared. So what I'm doing here is caching the
QueryableCourses collection in both the Memory and Redis cache. If,
after this caching, the memory cache is wiped, the Redis cache is
retrieved & put into the memory cache. This should be a nice bit of
redundancy.