### PR TITLE
Set root route to redirect to github pages

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "/", to: redirect("http://umn-asr.github.io/courses/")
+
   resources :terms, only: [:index]
   resources :campuses, only: [:index]
 


### PR DESCRIPTION
That's where the useful information is, so we might as well send people
there.