### PR TITLE
Extract Equivalency and CourseAttribute import out of CourseJsonImport

### DIFF
--- a/app/services/course_attribute_json_import.rb
+++ b/app/services/course_attribute_json_import.rb
@@ -1,0 +1,18 @@
+class CourseAttributeJsonImport
+  def initialize(json)
+    self.json = json
+  end
+
+  def run
+    course_attributes.each do |course_attribute|
+      CourseAttribute.create(attribute_id: course_attribute["attribute_id"], family: course_attribute["family"])
+    end
+  end
+
+  private
+  attr_accessor :json
+
+  def course_attributes
+    json["courses"].map { |course| course["course_attributes"] }.flatten.compact.uniq
+  end
+end

--- a/app/services/course_json_import.rb
+++ b/app/services/course_json_import.rb
@@ -17,13 +17,13 @@ class CourseJsonImport
 
       equivalency_json = course_json["equivalency"]
       if equivalency_json
-        equivalency = Equivalency.find_or_create_by(equivalency_json.slice("equivalency_id"))
+        equivalency = Equivalency.find_by(equivalency_json.slice("equivalency_id"))
         course_attr[:equivalency_id] = equivalency.id
       end
 
       course = Course.create(course_attr)
 
-      attributes = course_json["course_attributes"].map { |a| CourseAttribute.find_or_create_by(attribute_id: a["attribute_id"], family: a["family"]) }
+      attributes = course_json["course_attributes"].map { |a| CourseAttribute.find_by(attribute_id: a["attribute_id"], family: a["family"]) }
       course.course_attributes = attributes
 
       course_json["sections"].map do |section_json|

--- a/app/services/equivalency_json_import.rb
+++ b/app/services/equivalency_json_import.rb
@@ -1,0 +1,18 @@
+class EquivalencyJsonImport
+  def initialize(json)
+    self.json = json
+  end
+
+  def run
+    equivalencies.each do |equivalency|
+      Equivalency.create(equivalency_id: equivalency["equivalency_id"])
+    end
+  end
+
+  private
+  attr_accessor :json
+
+  def equivalencies
+    json["courses"].map { |course| course["equivalency"] }.flatten.compact
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,4 +42,6 @@ end
 f = File.open('test/fixtures/courses_example.json')
 j = JSON.parse(f.read)
 f.close
+CourseAttributeJsonImport.new(j).run
+EquivalencyJsonImport.new(j).run
 CourseJsonImport.new(j).run

--- a/lib/tasks/json_import.rake
+++ b/lib/tasks/json_import.rake
@@ -43,6 +43,8 @@ namespace :json_import do
     json_resources.each do |json|
       TermJsonImport.new(json).run
       CampusJsonImport.new(json).run
+      CourseAttributeJsonImport.new(json).run
+      EquivalencyJsonImport.new(json).run
     end
 
     number_of_parallel_processes = 3

--- a/spec/services/course_attribute_json_import_spec.rb
+++ b/spec/services/course_attribute_json_import_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe CourseAttributeJsonImport do
+  let (:course_json) { JSON.parse(File.read('test/fixtures/courses_example.json')) }
+  subject { described_class.new(course_json) }
+
+  describe "run" do
+    let(:course_attributes)     { course_json["courses"].map { |course| course["course_attributes"] }.flatten }
+
+    it "builds CourseAttributes for the supplied abbreviation" do
+      CourseAttribute.delete_all
+      subject.run
+
+      expect(CourseAttribute.all.count).to be > 0
+      course_attributes.compact.each do |attribute_hash|
+        expect(CourseAttribute.find_by(attribute_id: attribute_hash["attribute_id"], family: attribute_hash["family"])).to_not be_nil
+      end
+    end
+
+    it "is ok if the attribute already exists" do
+      CourseAttribute.create(attribute_id: course_attributes.first["attribute_id"], family: course_attributes.first["family"])
+      subject.run
+      course_attributes.compact.each do |attribute_hash|
+        expect(CourseAttribute.find_by(attribute_id: attribute_hash["attribute_id"], family: attribute_hash["family"])).to_not be_nil
+      end
+    end
+
+    it "is ok if a course has no attributes" do
+      course_json["courses"].first.delete("course_attributes")
+      expect(course_attributes).to include(nil)
+      subject.run
+      course_attributes.compact.each do |attribute_hash|
+        expect(CourseAttribute.find_by(attribute_id: attribute_hash["attribute_id"], family: attribute_hash["family"])).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/services/course_json_import_spec.rb
+++ b/spec/services/course_json_import_spec.rb
@@ -8,17 +8,7 @@ RSpec.describe CourseJsonImport, :type => :request do
 
   describe "run" do
     before do
-      %w(UMNTC UMNDL UMNMO UMNCR UMNRO).each do |abbreviation|
-        Campus.create({abbreviation: abbreviation})
-      end
-
-      %w(1149 1153 1155 1159 1163).each do |strm|
-        Term.create({strm: strm})
-      end
-
-      {"m" => "Monday", "t" => "Tuesday", "w" => "Wednesday", "th" => "Thursday", "f" => "Friday", "sa" => "Saturday", "su" => "Sunday"}.each do |abbreviation, name|
-        Day.create(abbreviation: abbreviation, name: name)
-      end
+      setup_cross_term_data
     end
 
     it "persits the json" do
@@ -34,6 +24,23 @@ RSpec.describe CourseJsonImport, :type => :request do
 
       expect(sort_json!(response_json)).to eq(sort_json!(course_json))
     end
+  end
+
+  def setup_cross_term_data
+    %w(UMNTC UMNDL UMNMO UMNCR UMNRO).each do |abbreviation|
+      Campus.create({abbreviation: abbreviation})
+    end
+
+    %w(1149 1153 1155 1159 1163).each do |strm|
+      Term.create({strm: strm})
+    end
+
+    {"m" => "Monday", "t" => "Tuesday", "w" => "Wednesday", "th" => "Thursday", "f" => "Friday", "sa" => "Saturday", "su" => "Sunday"}.each do |abbreviation, name|
+      Day.create(abbreviation: abbreviation, name: name)
+    end
+
+    CourseAttributeJsonImport.new(course_json).run
+    EquivalencyJsonImport.new(course_json).run
   end
 
   def sort_json!(class_json)

--- a/spec/services/equivalency_json_import_spec.rb
+++ b/spec/services/equivalency_json_import_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe EquivalencyJsonImport do
+  let (:course_json) { JSON.parse(File.read('test/fixtures/courses_example.json')) }
+  subject { described_class.new(course_json) }
+
+  describe "run" do
+    let(:equivalencies)     { course_json["courses"].map { |course| course["equivalency"] }.flatten }
+
+    it "builds Equivalencies for the supplied equivalency" do
+      Equivalency.delete_all
+      subject.run
+      expect(Equivalency.all.count).to be > 0
+      equivalencies.compact.each do |equivalency|
+        expect(Equivalency.find_by(equivalency_id: equivalency["equivalency_id"])).to_not be_nil
+      end
+    end
+
+    it "is ok if the attribute exists" do
+      Equivalency.create(equivalency_id: equivalencies.compact.first["equivalency_id"])
+      subject.run
+      equivalencies.compact.each do |equivalency|
+        expect(Equivalency.find_by(equivalency_id: equivalency["equivalency_id"])).to_not be_nil
+      end
+    end
+
+    it "is ok if a course has no equivalencies" do
+      expect(equivalencies).to include(nil)
+      subject.run
+      equivalencies.compact.each do |equivalency|
+        expect(Equivalency.find_by(equivalency_id: equivalency["equivalency_id"])).to_not be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are getting validation errors on duplicate CourseAttributes when we try to import them in parallel. This pull request extracts setting up CourseAttributes from CourseJsonImport so that import can be run in separately. Hopefully this avoids the uniqueness violations but we still get the time savings of running the twin cities course imports in parallel. 

We have not seen problems with Equivalencies yet (they are rarer) but they are also shared across terms, so extracting that setup as well.