### PR TITLE
Return 404 if url has invalid campus/term

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -5,9 +5,13 @@ class CoursesController < ApplicationController
     campus = Campus.fetch(params[:campus_id])
     term = Term.fetch(params[:term_id])
 
-    query_string_search = params[:q]
-    courses_to_retrieve = QueryStringSearch.new(QueryableCourses.fetch(campus, term), query_string_search).results.collect(&:course)
-    content = CoursesPresenter.fetch(campus, term, courses_to_retrieve)
-    render params[:format].to_sym => Serializer.serialize(content, params[:format])
+    if campus && term
+      query_string_search = params[:q]
+      courses_to_retrieve = QueryStringSearch.new(QueryableCourses.fetch(campus, term), query_string_search).results.collect(&:course)
+      content = CoursesPresenter.fetch(campus, term, courses_to_retrieve)
+      render params[:format].to_sym => Serializer.serialize(content, params[:format])
+    else
+      render nothing: true, status: 404
+    end
   end
 end

--- a/spec/requests/get_courses_spec.rb
+++ b/spec/requests/get_courses_spec.rb
@@ -17,4 +17,18 @@ RSpec.describe "get courses" do
       end
     end
   end
+
+  describe "with invalid campus" do
+    it "returns a 404" do
+      get "/campuses/uwmadison/terms/1149/courses.json"
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe "with invalid term" do
+    it "returns a 404" do
+      get "/campuses/UMNTC/terms/9999/courses.json"
+      expect(response.status).to eq(404)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #60

This fix is not my favorite, but I'm hard pressed to think of a reason
why we need something else. As this is the only place in the application
where we have to ask about the null-ness of the Campus & Term, we might
as well just do it in a conditional.