### PR TITLE
Configure cache expiration time in one place

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,6 +1,6 @@
 class CoursesController < ApplicationController
   def index
-    expires_in(48.hours, :public => true)
+    expires_in(Rails.configuration.caching.default_expiry, :public => true)
 
     campus = Campus.fetch(params[:campus_id])
     term = Term.fetch(params[:term_id])

--- a/config/initializers/cache.rb
+++ b/config/initializers/cache.rb
@@ -1,11 +1,14 @@
 if Rails.configuration.caching.use
-  Rails.configuration.action_dispatch.rack_cache = true
+  Rails.configuration.action_dispatch.rack_cache        = true
   Rails.configuration.action_controller.perform_caching = true
-  Rails.cache = CachePool.instance.current
-  FastCache = MemoryCache.instance
+  Rails.configuration.caching.default_expiry            = 48.hours
+  Rails.cache                                           = CachePool.instance.current
+  FastCache                                             = MemoryCache.instance
+  Rails.cache.options[:expires_in]                      = Rails.configuration.caching.default_expiry
+  FastCache.options[:expires_in]                        = Rails.configuration.caching.default_expiry
 else
-  Rails.configuration.action_dispatch.rack_cache = false
+  Rails.configuration.action_dispatch.rack_cache        = false
   Rails.configuration.action_controller.perform_caching = false
-  Rails.cache = ActiveSupport::Cache::NullStore.new
-  FastCache = ActiveSupport::Cache::NullStore.new
+  Rails.cache                                           = ActiveSupport::Cache::NullStore.new
+  FastCache                                             = ActiveSupport::Cache::NullStore.new
 end

--- a/lib/cache_pool.rb
+++ b/lib/cache_pool.rb
@@ -28,7 +28,7 @@ class CachePool
 
   def build_pool
     1.upto(pool_size).each do |i|
-      pool << ActiveSupport::Cache.lookup_store(:redis_store, redis_configuration.merge(db: i, expires_in: 48.hours))
+      pool << ActiveSupport::Cache.lookup_store(:redis_store, redis_configuration.merge(db: i))
     end
   end
 

--- a/spec/lib/cache_pool_spec.rb
+++ b/spec/lib/cache_pool_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CachePool do
     end
 
     it "has an expiration of 48 hours" do
-      expect(subject.current.options[:expires_in]).to eq(48.hours)
+      expect(subject.current.options[:expires_in]).to eq(Rails.configuration.caching.default_expiry)
     end
 
     context "when current_cache_db is not set in redis" do


### PR DESCRIPTION
Fixes #76

This commit sets a default cache expiration time in the caching
initializer. It then configures our two caches to use that time. The
http caching calls in the controller also uses the default time.