### PR TITLE
Clear cache before populating

### DIFF
--- a/app/services/cache_warmer.rb
+++ b/app/services/cache_warmer.rb
@@ -8,14 +8,23 @@ class CacheWarmer
   end
 
   def warm
+    clear_cache
+    populate_cache
+  end
+
+  private
+  attr_accessor :cache
+
+  def clear_cache
+    cache.clear
+  end
+
+  def populate_cache
     cache_terms
     cache_campuses
     cache_queryable_courses
     cache_full_courses
   end
-
-  private
-  attr_accessor :cache
 
   def cache_terms
     terms.each { |term| Term.fetch(term.strm, cache)}

--- a/spec/services/cache_warmer_spec.rb
+++ b/spec/services/cache_warmer_spec.rb
@@ -20,11 +20,17 @@ RSpec.describe CacheWarmer do
     let(:campuses)  { generate_campuses }
 
     before do
+      allow(cache).to             receive(:clear)
       allow(Campus).to            receive(:all).and_return(campuses)
       allow(Term).to              receive(:all).and_return(terms)
       allow(Campus).to            receive(:fetch)
       allow(Term).to              receive(:fetch)
       allow(QueryableCourses).to  receive(:fetch)
+    end
+
+    it "clears the cache" do
+      expect(cache).to receive(:clear)
+      subject.warm
     end
 
     it "caches all terms with its cache" do


### PR DESCRIPTION
fixes #86 with baf5f74. 

When reusing a cache from the CachePool pool, we need to make sure no old data lingers when we warm it with the current data. Because the redis cache is implemented as an ActiveSupport::Cache::Store we can use the #clear method of the ActiveSupport::Cache::Store api