### PR TITLE
Require the presence of instruction_mode_id

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -6,7 +6,7 @@ class Section < ::ActiveRecord::Base
   has_many :meeting_patterns, -> { order "start_date" }
   has_many :combined_sections
 
-  validates_presence_of :class_number, :number, :component, :course_id
+  validates_presence_of :class_number, :number, :component, :course_id, :instruction_mode_id
 
   def type
     "section"

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Section do
   end
 
   describe "valid?" do
-    let(:valid_attributes) { {course_id: rand(3), class_number: "#{rand(3)}", number: "#{rand(3)}", component: "LEC" } }
+    let(:valid_attributes) { {course_id: rand(3), class_number: "#{rand(3)}", number: "#{rand(3)}", component: "LEC", instruction_mode_id: rand(3) } }
 
     it "is valid with the correct attributes" do
       expect(described_class.new(valid_attributes).valid?).to be_truthy


### PR DESCRIPTION
Fixes #87

We see an occasional bug where a section in the XML file does not have an
instruction_mode. Instead of letting this section into the database, I
think we should reject it for being invalid.

If further research shows that it's valid for a section to not
have an instruction_mode, then we can revisit this fix.