### PR TITLE
Update Import to Accept Missing Resources

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -45,6 +45,6 @@ class Course < ::ActiveRecord::Base
       equivalency: equivalency.to_h,
       course_attributes: course_attributes.map { |ca| ca.to_h },
       sections: sections.map { |s| s.to_h }
-    }.delete_if { |_, value| value.blank? }
+    }.delete_if { |_, value| value == {} }
   end
 end

--- a/app/models/meeting_pattern.rb
+++ b/app/models/meeting_pattern.rb
@@ -16,7 +16,7 @@ class MeetingPattern < ::ActiveRecord::Base
       end_date: date_format(end_date),
       location: location.to_h,
       days: days.map { |d| d.to_h }
-    }
+    }.delete_if { |_, value| value == {} }
   end
 
   private

--- a/app/models/queryable_course.rb
+++ b/app/models/queryable_course.rb
@@ -7,7 +7,7 @@ class QueryableCourse
     self.catalog_number = full_course.catalog_number
     self.course_attribute_family = (full_course.course_attributes.collect { |a| a.family }).to_set
     self.course_attribute_id = (full_course.course_attributes.collect { |a| a.attribute_id }).to_set
-    self.instruction_mode_id = (full_course.sections.collect { |s| s.instruction_mode.instruction_mode_id}).to_set
+    self.instruction_mode_id = (full_course.sections.collect { |s| s.instruction_mode }.compact.collect { |im| im.instruction_mode_id}).to_set
     self.locations = (full_course.sections.collect { |s| s.location}).to_set
   end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -28,6 +28,6 @@ class Section < ::ActiveRecord::Base
       instructors: instructors.map { |i| i.to_h },
       meeting_patterns: meeting_patterns.map { |mp| mp.to_h },
       combined_sections: combined_sections.map { |cs| cs.to_h },
-    }
+    }.delete_if { |_, value| value == {} }
   end
 end

--- a/app/services/course_json_import.rb
+++ b/app/services/course_json_import.rb
@@ -63,7 +63,7 @@ class CourseJsonImport
   attr_accessor :json
 
   def parse_resource(resource_class, json_node, attribute_mapping)
-    if json_node
+    if json_node && json_node.present?
       attributes = attribute_mapping.each_with_object({}) do |(json_key, attr_name), hash|
                       hash[attr_name] = json_node[json_key]
                     end

--- a/app/services/course_json_import.rb
+++ b/app/services/course_json_import.rb
@@ -63,7 +63,7 @@ class CourseJsonImport
   attr_accessor :json
 
   def parse_resource(resource_class, json_node, attribute_mapping)
-    if json_node && json_node.present?
+    if json_node.present?
       attributes = attribute_mapping.each_with_object({}) do |(json_key, attr_name), hash|
                       hash[attr_name] = json_node[json_key]
                     end

--- a/app/services/course_json_import.rb
+++ b/app/services/course_json_import.rb
@@ -4,18 +4,18 @@ class CourseJsonImport
   end
 
   def run
+    campus = Campus.where(abbreviation: json["campus"]["abbreviation"]).first
+    term = Term.where(strm: json["term"]["strm"]).first
+
     json["courses"].each do |course_json|
       course_attr = Hash.new
       course_attr = course_json.slice("title", "description", "course_id", "catalog_number")
 
-      campus = Campus.where(abbreviation: json["campus"]["abbreviation"]).first
-
-      term = Term.where(strm: json["term"]["strm"]).first
-
-      subject = Subject.find_or_create_by(course_json["subject"].slice("subject_id", "description").merge({campus_id: campus.id, term_id: term.id}))
+      subject = parse_resource(Subject, course_json["subject"], {"subject_id" => "subject_id", "description" => "description"})
+      subject.update(campus_id: campus.id, term_id: term.id)
       course_attr[:subject_id] = subject.id
 
-      equivalency = parse_resource(Equivalency, course_json["equivalency"], ["equivalency_id"])
+      equivalency = parse_resource(Equivalency, course_json["equivalency"], {"equivalency_id" => "equivalency_id"})
       if equivalency
         course_attr[:equivalency_id] = equivalency.id
       end
@@ -27,20 +27,22 @@ class CourseJsonImport
 
       course_json["sections"].map do |section_json|
         section = course.sections.build(section_json.slice("class_number", "number", "component", "credits_minimum", "credits_maximum", "location", "notes"))
-        section.instruction_mode = parse_resource(InstructionMode, section_json["instruction_mode"], ["instruction_mode_id","description"])
-        section.grading_basis = parse_resource(GradingBasis, section_json["grading_basis"], ["grading_basis_id","description"])
+        section.instruction_mode = parse_resource(InstructionMode, section_json["instruction_mode"], {"instruction_mode_id" => "instruction_mode_id","description" => "description"})
+        section.grading_basis = parse_resource(GradingBasis, section_json["grading_basis"], {"grading_basis_id" => "grading_basis_id", "description" => "description"})
         section.save
 
         section_json["instructors"].each do |instructor_json|
-          role = InstructorRole.find_or_create_by(abbreviation: instructor_json["role"])
-          contact = parse_resource(InstructorContact, instructor_json, ["name","email"])
+          role = parse_resource(InstructorRole, instructor_json, {"role" => "abbreviation"})
+          contact = parse_resource(InstructorContact, instructor_json, {"name" => "name","email" => "email"})
           section.instructors.create(instructor_role: role, instructor_contact: contact)
         end
 
         section_json["meeting_patterns"].each do |pattern_json|
-          mp = section.meeting_patterns.create(pattern_json.slice("start_time","end_time","start_date","end_date"))
+          mp = parse_resource(MeetingPattern, pattern_json, {"start_time" => "start_time","end_time" => "end_time","start_date" => "start_date","end_date" => "end_date"})
+          mp.section_id = section.id
+          mp.save
 
-          mp.location = parse_resource(Location, pattern_json["location"], ["location_id","description"])
+          mp.location = parse_resource(Location, pattern_json["location"], {"location_id" => "location_id","description" => "description"})
 
           pattern_json["days"].each do |day|
             mp.days << Day.find_by_abbreviation(day["abbreviation"])
@@ -60,9 +62,12 @@ class CourseJsonImport
   private
   attr_accessor :json
 
-  def parse_resource(resource_class, json_node, attribute_keys)
+  def parse_resource(resource_class, json_node, attribute_mapping)
     if json_node
-      resource_class.find_or_create_by(json_node.slice(*attribute_keys))
+      attributes = attribute_mapping.each_with_object({}) do |(json_key, attr_name), hash|
+                      hash[attr_name] = json_node[json_key]
+                    end
+      resource_class.find_or_create_by(attributes)
     end
   end
 end

--- a/app/services/course_json_import.rb
+++ b/app/services/course_json_import.rb
@@ -28,10 +28,8 @@ class CourseJsonImport
 
       course_json["sections"].map do |section_json|
         section = course.sections.build(section_json.slice("class_number", "number", "component", "credits_minimum", "credits_maximum", "location", "notes"))
-        section.instruction_mode = InstructionMode.find_or_create_by(section_json["instruction_mode"].slice("instruction_mode_id","description"))
-        section.grading_basis = GradingBasis.find_or_create_by(section_json["grading_basis"].slice("grading_basis_id","description"))
-
-        section.grading_basis = GradingBasis.find_or_create_by(section_json["grading_basis"].slice("grading_basis_id","description"))
+        section.instruction_mode = parse_resource(InstructionMode, section_json["instruction_mode"], ["instruction_mode_id","description"])
+        section.grading_basis = parse_resource(GradingBasis, section_json["grading_basis"], ["grading_basis_id","description"])
         section.save
 
         section_json["instructors"].each do |instructor_json|
@@ -65,4 +63,10 @@ class CourseJsonImport
 
   private
   attr_accessor :json
+
+  def parse_resource(resource_class, json_node, attribute_keys)
+    if json_node
+      resource_class.find_or_create_by(json_node.slice(*attribute_keys))
+    end
+  end
 end

--- a/test/fixtures/no_grading_basis_for_section_102.json
+++ b/test/fixtures/no_grading_basis_for_section_102.json
@@ -1,0 +1,573 @@
+{
+  "campus": {
+    "type": "campus",
+    "campus_id": "UMNTC",
+    "abbreviation": "UMNTC"
+  },
+  "term": {
+    "type": "term",
+    "term_id": "1149",
+    "strm": "1149"
+  },
+  "courses": [
+    {
+      "type": "course",
+      "course_id": "002066",
+      "catalog_number": "1101W",
+      "description": "Fundamental principles of physics in the context of everyday world. Use of kinematics/dynamics principles and quantitative/qualitative problem solving techniques to understand natural phenomena. Lecture, recitation, lab.",
+      "title": "Intro College Phys I",
+      "subject": {
+        "type": "subject",
+        "subject_id": "PHYS",
+        "description": "Physics"
+      },
+      "course_attributes": [
+        {
+          "type": "attribute",
+          "attribute_id": "WI",
+          "family": "CLE"
+        },
+        {
+          "type": "attribute",
+          "attribute_id": "PHYS",
+          "family": "CLE"
+        }
+      ],
+      "sections": [
+        {
+          "type": "section",
+          "class_number": "10786",
+          "number": "100",
+          "component": "LEC",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Vincent Noireaux",
+              "email": "email@umn.edu",
+              "role": "PI"
+            },
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "13:25",
+              "end_time": "14:15",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "PHYS00150",
+                "description": "Phys 150"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "monday",
+                  "abbreviation": "m"
+                },
+                {
+                  "type": "day",
+                  "name": "wednesday",
+                  "abbreviation": "w"
+                },
+                {
+                  "type": "day",
+                  "name": "friday",
+                  "abbreviation": "f"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10787",
+          "number": "102",
+          "component": "DIS",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Jarrett Brown",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "13:25",
+              "end_time": "14:15",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "FORDH00170",
+                "description": "Ford Hall 170"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "thursday",
+                  "abbreviation": "th"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10788",
+          "number": "103",
+          "component": "LAB",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Vincent Noireaux",
+              "email": "email@umn.edu",
+              "role": "PI"
+            },
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Jarrett Brown",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "16:40",
+              "end_time": "18:35",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "PHYS000130",
+                "description": "Tate Laboratory 130"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "monday",
+                  "abbreviation": "m"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10789",
+          "number": "104",
+          "component": "DIS",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Hannah Rogers",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "13:25",
+              "end_time": "14:15",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "STSS000117",
+                "description": "Science Tchg Student Svcs 117"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "thursday",
+                  "abbreviation": "th"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10790",
+          "number": "105",
+          "component": "LAB",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Vincent Noireaux",
+              "email": "email@umn.edu",
+              "role": "PI"
+            },
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Hannah Rogers",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "10:10",
+              "end_time": "12:05",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "PHYS000130",
+                "description": "Tate Laboratory 130"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "tuesday",
+                  "abbreviation": "t"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10791",
+          "number": "106",
+          "component": "DIS",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Kent Bodurtha",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "13:25",
+              "end_time": "14:15",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "PEIKH00335",
+                "description": "Peik Hall 335"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "thursday",
+                  "abbreviation": "th"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10792",
+          "number": "107",
+          "component": "LAB",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Vincent Noireaux",
+              "email": "email@umn.edu",
+              "role": "PI"
+            },
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Kent Bodurtha",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "11:15",
+              "end_time": "13:10",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "PHYS000130",
+                "description": "Tate Laboratory 130"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "thursday",
+                  "abbreviation": "th"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10793",
+          "number": "108",
+          "component": "DIS",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Michael Kreshchuk",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "13:25",
+              "end_time": "14:15",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "BUH0000120",
+                "description": "Burton Hall 120"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "thursday",
+                  "abbreviation": "th"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10794",
+          "number": "109",
+          "component": "LAB",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Vincent Noireaux",
+              "email": "email@umn.edu",
+              "role": "PI"
+            },
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Michael Kreshchuk",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "12:20",
+              "end_time": "14:15",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "PHYS000130",
+                "description": "Tate Laboratory 130"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "tuesday",
+                  "abbreviation": "t"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/no_instruction_mode_for_section_104.json
+++ b/test/fixtures/no_instruction_mode_for_section_104.json
@@ -1,0 +1,671 @@
+{
+  "campus": {
+    "type": "campus",
+    "campus_id": "UMNTC",
+    "abbreviation": "UMNTC"
+  },
+  "term": {
+    "type": "term",
+    "term_id": "1149",
+    "strm": "1149"
+  },
+  "courses": [
+    {
+      "type": "course",
+      "course_id": "002066",
+      "catalog_number": "1101W",
+      "description": "Fundamental principles of physics in the context of everyday world. Use of kinematics/dynamics principles and quantitative/qualitative problem solving techniques to understand natural phenomena. Lecture, recitation, lab.",
+      "title": "Intro College Phys I",
+      "subject": {
+        "type": "subject",
+        "subject_id": "PHYS",
+        "description": "Physics"
+      },
+      "course_attributes": [
+        {
+          "type": "attribute",
+          "attribute_id": "WI",
+          "family": "CLE"
+        },
+        {
+          "type": "attribute",
+          "attribute_id": "PHYS",
+          "family": "CLE"
+        }
+      ],
+      "sections": [
+        {
+          "type": "section",
+          "class_number": "10786",
+          "number": "100",
+          "component": "LEC",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Vincent Noireaux",
+              "email": "email@umn.edu",
+              "role": "PI"
+            },
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "13:25",
+              "end_time": "14:15",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "PHYS00150",
+                "description": "Phys 150"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "monday",
+                  "abbreviation": "m"
+                },
+                {
+                  "type": "day",
+                  "name": "wednesday",
+                  "abbreviation": "w"
+                },
+                {
+                  "type": "day",
+                  "name": "friday",
+                  "abbreviation": "f"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10787",
+          "number": "102",
+          "component": "DIS",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Jarrett Brown",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "13:25",
+              "end_time": "14:15",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "FORDH00170",
+                "description": "Ford Hall 170"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "thursday",
+                  "abbreviation": "th"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10788",
+          "number": "103",
+          "component": "LAB",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Vincent Noireaux",
+              "email": "email@umn.edu",
+              "role": "PI"
+            },
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Jarrett Brown",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "16:40",
+              "end_time": "18:35",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "PHYS000130",
+                "description": "Tate Laboratory 130"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "monday",
+                  "abbreviation": "m"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10789",
+          "number": "104",
+          "component": "DIS",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Hannah Rogers",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "13:25",
+              "end_time": "14:15",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "STSS000117",
+                "description": "Science Tchg Student Svcs 117"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "thursday",
+                  "abbreviation": "th"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10790",
+          "number": "105",
+          "component": "LAB",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Vincent Noireaux",
+              "email": "email@umn.edu",
+              "role": "PI"
+            },
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Hannah Rogers",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "10:10",
+              "end_time": "12:05",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "PHYS000130",
+                "description": "Tate Laboratory 130"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "tuesday",
+                  "abbreviation": "t"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10791",
+          "number": "106",
+          "component": "DIS",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Kent Bodurtha",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "13:25",
+              "end_time": "14:15",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "PEIKH00335",
+                "description": "Peik Hall 335"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "thursday",
+                  "abbreviation": "th"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10792",
+          "number": "107",
+          "component": "LAB",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Vincent Noireaux",
+              "email": "email@umn.edu",
+              "role": "PI"
+            },
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Kent Bodurtha",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "11:15",
+              "end_time": "13:10",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "PHYS000130",
+                "description": "Tate Laboratory 130"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "thursday",
+                  "abbreviation": "th"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10793",
+          "number": "108",
+          "component": "DIS",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Michael Kreshchuk",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "13:25",
+              "end_time": "14:15",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "BUH0000120",
+                "description": "Burton Hall 120"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "thursday",
+                  "abbreviation": "th"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        },
+        {
+          "type": "section",
+          "class_number": "10794",
+          "number": "109",
+          "component": "LAB",
+          "location": "TCEASTBANK",
+          "credits_minimum": "4",
+          "credits_maximum": "4",
+          "notes": "3-hr common final exam",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "OPT",
+            "description": "Student Option"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Vincent Noireaux",
+              "email": "email@umn.edu",
+              "role": "PI"
+            },
+            {
+              "type": "instructor",
+              "name": "Jennifer Kroschel",
+              "email": "email@umn.edu",
+              "role": "PRXY"
+            },
+            {
+              "type": "instructor",
+              "name": "Michael Kreshchuk",
+              "email": "email@umn.edu",
+              "role": "TA"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "12:20",
+              "end_time": "14:15",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "PHYS000130",
+                "description": "Tate Laboratory 130"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "tuesday",
+                  "abbreviation": "t"
+                }
+              ]
+            }
+          ],
+          "combined_sections": []
+        }
+      ]
+    },
+    {
+      "type": "course",
+      "course_id": "795342",
+      "catalog_number": "3120",
+      "description": "Political, cultural, historical linkages between Africans, African-Americans, African-Caribbean. Black socio-political movements/radical intellectual trends in late 19th/20th centuries. Colonialism/racism. Protest organizations, radical movements in United States/Europe.",
+      "title": "Soc Mvts in African Diaspora",
+      "subject": {
+        "type": "subject",
+        "subject_id": "AFRO",
+        "description": "African Amer & African Studies"
+      },
+      "equivalency": {
+        "type": "equivalency",
+        "equivalency_id": "00788"
+      },
+      "course_attributes": [
+        {
+          "type": "attribute",
+          "attribute_id": "HIS",
+          "family": "CLE"
+        },
+        {
+          "type": "attribute",
+          "attribute_id": "GP",
+          "family": "CLE"
+        }
+      ],
+      "sections": [
+        {
+          "type": "section",
+          "class_number": "26191",
+          "number": "001",
+          "component": "LEC",
+          "location": "TCWESTBANK",
+          "credits_minimum": "3",
+          "credits_maximum": "3",
+          "notes": "",
+          "instruction_mode": {
+            "type": "instruction_mode",
+            "instruction_mode_id": "P",
+            "description": "In Person Term Based"
+          },
+          "grading_basis": {
+            "type": "grading_basis",
+            "grading_basis_id": "AFV",
+            "description": "A-F or Audit"
+          },
+          "instructors": [
+            {
+              "type": "instructor",
+              "name": "Yuichiro Onishi",
+              "email": "email@umn.edu",
+              "role": "PI"
+            }
+          ],
+          "meeting_patterns": [
+            {
+              "type": "meeting_pattern",
+              "start_time": "13:00",
+              "end_time": "14:15",
+              "start_date": "2014-09-02",
+              "end_date": "2014-12-10",
+              "location": {
+                "type": "location",
+                "location_id": "BLEGH00245",
+                "description": "Blegen Hall 245"
+              },
+              "days": [
+                {
+                  "type": "day",
+                  "name": "tuesday",
+                  "abbreviation": "t"
+                },
+                {
+                  "type": "day",
+                  "name": "thursday",
+                  "abbreviation": "th"
+                }
+              ]
+            }
+          ],
+          "combined_sections": [
+            {
+              "type": "combined_section",
+              "catalog_number": "3456",
+              "subject_id": "HIST",
+              "section_number": "001"
+            },
+            {
+              "type": "combined_section",
+              "catalog_number": "5120",
+              "subject_id": "AFRO",
+              "section_number": "001"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
While testing the updated course xml service we encountered several instances where data that we were requiring (e.g. grading basis, instruction mode) was not present, and its absence was causing errors with the import. While this was test data, we were told similarly incomplete data could occur in production if the course was not set up properly in PeopleSoft. 

This PR updates CourseJsonImport process to ignore missing data. The previous version of the import was raising an exception when we called slice on a missing node in the json. This version only parses if the node exists and ignores missing nodes.

There are also some updates to other parts of the system that break once this data is missing: 
  1. a missing instruction mode was breaking our cache process (see issue #87) 
  1. the #to_h method needs to not include a node for these missing resources, but include a node for an empty attribute
