### PR TITLE
Return courses ordered by subject description, catalog number

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -9,7 +9,7 @@ class Course < ::ActiveRecord::Base
   validates_presence_of :subject_id, :course_id
   validates_uniqueness_of :course_id, scope: [:subject_id]
 
-  scope :for_campus_and_term, ->(campus, term) { joins(:subject).where(subjects: { campus_id: campus.id, term_id: term.id }) }
+  scope :for_campus_and_term, ->(campus, term) { joins(:subject).where(subjects: { campus_id: campus.id, term_id: term.id }).order('subjects.description, courses.catalog_number') }
 
   def self.cache_key_for_instance(id)
     "#{type}_#{id}"

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -27,9 +27,11 @@ RSpec.describe Course do
       expect(Course.for_campus_and_term(campus, term)).to eq(courses)
       expect(Course.for_campus_and_term(campus, term)).to_not include(other_course)
     end
+
     it "returns an empty collection when there are no matches" do
       expect(Course.for_campus_and_term(other_campus, other_term)).to be_empty
     end
+
     it "does not return the course when the campus matches but the term does not" do
       expect(Course.for_campus_and_term(campus, other_term)).to be_empty
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Course do
       expect(Course.for_campus_and_term(other_campus, term)).to be_empty
     end
 
-    it "returns courses in order of subject description", :focus do
+    it "returns courses in order of subject description" do
       aab_subject = Subject.create(subject_id: "#{rand(100)}", description: "aab", campus_id: campus.id, term_id: term.id)
       aab_course = aab_subject.courses.create(course_id: rand(1000..9999).to_s)
       aaa_subject = Subject.create(subject_id: "#{rand(100)}", description: "aaa", campus_id: campus.id, term_id: term.id)
@@ -50,7 +50,7 @@ RSpec.describe Course do
       expect(Course.for_campus_and_term(campus, term).last).to eq(aab_course)
     end
 
-    it "within a subject, courses are returned by catalog number", :focus do
+    it "within a subject, courses are returned by catalog number" do
       aaa_subject = Subject.create(subject_id: "#{rand(100)}", description: "aaa", campus_id: campus.id, term_id: term.id)
       course_last = aaa_subject.courses.create(course_id: rand(1000..9999).to_s, catalog_number: '1000W')
       course_first = aaa_subject.courses.create(course_id: rand(1000..9999).to_s, catalog_number: '1000')

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -37,6 +37,25 @@ RSpec.describe Course do
     it "does not return the course when the term matches but the campus does not" do
       expect(Course.for_campus_and_term(other_campus, term)).to be_empty
     end
+
+    it "returns courses in order of subject description", :focus do
+      aab_subject = Subject.create(subject_id: "#{rand(100)}", description: "aab", campus_id: campus.id, term_id: term.id)
+      aab_course = aab_subject.courses.create(course_id: rand(1000..9999).to_s)
+      aaa_subject = Subject.create(subject_id: "#{rand(100)}", description: "aaa", campus_id: campus.id, term_id: term.id)
+      aaa_course = aaa_subject.courses.create(course_id: rand(1000..9999).to_s)
+
+      expect(Course.for_campus_and_term(campus, term).first).to eq(aaa_course)
+      expect(Course.for_campus_and_term(campus, term).last).to eq(aab_course)
+    end
+
+    it "within a subject, courses are returned by catalog number", :focus do
+      aaa_subject = Subject.create(subject_id: "#{rand(100)}", description: "aaa", campus_id: campus.id, term_id: term.id)
+      course_last = aaa_subject.courses.create(course_id: rand(1000..9999).to_s, catalog_number: '1000W')
+      course_first = aaa_subject.courses.create(course_id: rand(1000..9999).to_s, catalog_number: '1000')
+
+      expect(Course.for_campus_and_term(campus, term).first).to eq(course_first)
+      expect(Course.for_campus_and_term(campus, term).last).to eq(course_last)
+    end
   end
 
   describe "type" do


### PR DESCRIPTION
Fixes #95

The scope that is used to return our sets of courses is
`for_campus_and_term`, so I've only added and tested the ordering there.