### PR TITLE
Iw/fix schema datatypes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rsim/oracle-enhanced.git
-  revision: 83666d3691a451235f11a882a8dbd68dce47a365
+  revision: 5dd239311a11cb65792484ece06d32761d06ec7d
   branch: rails42
   specs:
     activerecord-oracle_enhanced-adapter (1.5.6)

--- a/db/migrate/20150318010910_create_meeting_patterns.rb
+++ b/db/migrate/20150318010910_create_meeting_patterns.rb
@@ -4,8 +4,8 @@ class CreateMeetingPatterns < ActiveRecord::Migration
       t.belongs_to :section
       t.string :start_time
       t.string :end_time
-      t.date :start_date
-      t.date :end_date
+      t.datetime :start_date
+      t.datetime :end_date
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,9 +48,6 @@ ActiveRecord::Schema.define(version: 20150601153229) do
     t.string  "catalog_number"
     t.integer "subject_id"
     t.integer "equivalency_id"
-    t.string  "repeatable"
-    t.string  "units_repeat_limit"
-    t.string  "repeat_limit"
   end
 
   add_index "courses", ["campus_id"], name: "index_courses_on_campus_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,110 +11,115 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150408205701) do
+ActiveRecord::Schema.define(version: 20150601153229) do
 
-  create_table "campuses", force: true do |t|
+  create_table "campuses", force: :cascade do |t|
     t.string "abbreviation"
   end
 
   add_index "campuses", ["abbreviation"], name: "index_campuses_on_abbreviation", unique: true
 
-  create_table "combined_sections", force: true do |t|
-    t.integer "section_id",     limit: nil, precision: 38
+  create_table "combined_sections", force: :cascade do |t|
+    t.integer "section_id"
     t.string  "catalog_number"
     t.string  "subject_id"
     t.string  "section_number"
   end
 
-  create_table "course_attributes", force: true do |t|
+  create_table "course_attributes", force: :cascade do |t|
     t.string "attribute_id"
     t.string "family"
   end
 
-  create_table "course_attributes_courses", id: false, force: true do |t|
-    t.integer "course_id",           limit: nil, precision: 38
-    t.integer "course_attribute_id", limit: nil, precision: 38
+  create_table "course_attributes_courses", id: false, force: :cascade do |t|
+    t.integer "course_id"
+    t.integer "course_attribute_id"
   end
 
-  add_index "course_attributes_courses", ["course_attribute_id"], name: "i_cou_att_cou_cou_att_id"
-  add_index "course_attributes_courses", ["course_id"], name: "i_cou_att_cou_cou_id"
+  add_index "course_attributes_courses", ["course_attribute_id"], name: "index_course_attributes_courses_on_course_attribute_id"
+  add_index "course_attributes_courses", ["course_id"], name: "index_course_attributes_courses_on_course_id"
 
-  create_table "courses", force: true do |t|
-    t.integer "term_id",        limit: nil, precision: 38
+  create_table "courses", force: :cascade do |t|
+    t.integer "campus_id"
+    t.integer "term_id"
     t.string  "course_id"
     t.string  "title"
-    t.text    "description"
+    t.string  "description"
     t.string  "catalog_number"
-    t.integer "subject_id",     limit: nil, precision: 38
-    t.integer "equivalency_id", limit: nil, precision: 38
+    t.integer "subject_id"
+    t.integer "equivalency_id"
+    t.string  "repeatable"
+    t.string  "units_repeat_limit"
+    t.string  "repeat_limit"
   end
 
-  add_index "courses", ["equivalency_id"], name: "i_courses_equivalency_id"
+  add_index "courses", ["campus_id"], name: "index_courses_on_campus_id"
+  add_index "courses", ["equivalency_id"], name: "index_courses_on_equivalency_id"
   add_index "courses", ["subject_id"], name: "index_courses_on_subject_id"
   add_index "courses", ["term_id"], name: "index_courses_on_term_id"
 
-  create_table "days", force: true do |t|
+  create_table "days", force: :cascade do |t|
     t.string "name"
     t.string "abbreviation"
   end
 
-  create_table "days_meeting_patterns", id: false, force: true do |t|
-    t.integer "day_id",             limit: nil, precision: 38
-    t.integer "meeting_pattern_id", limit: nil, precision: 38
+  create_table "days_meeting_patterns", id: false, force: :cascade do |t|
+    t.integer "day_id"
+    t.integer "meeting_pattern_id"
   end
 
-  add_index "days_meeting_patterns", ["day_id"], name: "i_days_meeting_patterns_day_id"
-  add_index "days_meeting_patterns", ["meeting_pattern_id"], name: "i_day_mee_pat_mee_pat_id"
+  add_index "days_meeting_patterns", ["day_id"], name: "index_days_meeting_patterns_on_day_id"
+  add_index "days_meeting_patterns", ["meeting_pattern_id"], name: "index_days_meeting_patterns_on_meeting_pattern_id"
 
-  create_table "equivalencies", force: true do |t|
+  create_table "equivalencies", force: :cascade do |t|
     t.string "equivalency_id"
   end
 
-  create_table "grading_bases", force: true do |t|
+  create_table "grading_bases", force: :cascade do |t|
     t.string "grading_basis_id"
     t.string "description"
   end
 
-  create_table "instruction_modes", force: true do |t|
+  create_table "instruction_modes", force: :cascade do |t|
     t.string "instruction_mode_id"
     t.string "description"
   end
 
-  create_table "instructor_contacts", force: true do |t|
+  create_table "instructor_contacts", force: :cascade do |t|
     t.string "name"
     t.string "email"
   end
 
-  create_table "instructor_roles", force: true do |t|
+  create_table "instructor_roles", force: :cascade do |t|
     t.string "abbreviation"
   end
 
-  create_table "instructors", force: true do |t|
-    t.integer "instructor_contact_id", limit: nil, precision: 38
-    t.integer "section_id",            limit: nil, precision: 38
-    t.integer "instructor_role_id",    limit: nil, precision: 38
+  create_table "instructors", force: :cascade do |t|
+    t.integer "instructor_contact_id"
+    t.integer "section_id"
+    t.integer "instructor_role_id"
   end
 
-  add_index "instructors", ["instructor_contact_id"], name: "i_ins_ins_con_id"
-  add_index "instructors", ["instructor_role_id"], name: "i_ins_ins_rol_id"
-  add_index "instructors", ["section_id"], name: "i_instructors_section_id"
+  add_index "instructors", ["instructor_contact_id"], name: "index_instructors_on_instructor_contact_id"
+  add_index "instructors", ["instructor_role_id"], name: "index_instructors_on_instructor_role_id"
+  add_index "instructors", ["section_id"], name: "index_instructors_on_section_id"
 
-  create_table "locations", force: true do |t|
+  create_table "locations", force: :cascade do |t|
     t.string "location_id"
     t.string "description"
   end
 
-  create_table "meeting_patterns", force: true do |t|
-    t.integer  "section_id",  limit: nil, precision: 38
+  create_table "meeting_patterns", force: :cascade do |t|
+    t.integer  "section_id"
     t.string   "start_time"
     t.string   "end_time"
     t.datetime "start_date"
     t.datetime "end_date"
-    t.integer  "location_id", limit: nil, precision: 38
+    t.integer  "location_id"
   end
 
-  create_table "sections", force: true do |t|
-    t.integer "course_id",           limit: nil, precision: 38
+  create_table "sections", force: :cascade do |t|
+    t.integer "course_id"
     t.string  "class_number"
     t.string  "number"
     t.string  "component"
@@ -122,29 +127,26 @@ ActiveRecord::Schema.define(version: 20150408205701) do
     t.string  "credits_minimum"
     t.string  "credits_maximum"
     t.text    "notes"
-    t.integer "instruction_mode_id", limit: nil, precision: 38
-    t.integer "grading_basis_id",    limit: nil, precision: 38
+    t.integer "instruction_mode_id"
+    t.integer "grading_basis_id"
   end
 
   add_index "sections", ["course_id"], name: "index_sections_on_course_id"
 
-  create_table "subjects", force: true do |t|
+  create_table "subjects", force: :cascade do |t|
     t.string  "subject_id"
     t.string  "description"
-    t.integer "campus_id",   limit: nil, precision: 38
-    t.integer "term_id",     limit: nil, precision: 38
+    t.integer "campus_id"
+    t.integer "term_id"
   end
 
   add_index "subjects", ["campus_id"], name: "index_subjects_on_campus_id"
   add_index "subjects", ["term_id"], name: "index_subjects_on_term_id"
 
-  create_table "terms", force: true do |t|
+  create_table "terms", force: :cascade do |t|
     t.string "strm"
   end
 
   add_index "terms", ["strm"], name: "index_terms_on_strm", unique: true
-
-  add_foreign_key "subjects", "campuses", name: "subjects_campus_id_fk"
-  add_foreign_key "subjects", "terms", name: "subjects_term_id_fk"
 
 end


### PR DESCRIPTION
The schema.rb file is altered depending on what db platform you run db
tasks against. Run a migration against Oracle, and a bunch of this file
changes. Run the migration against Sqlite afterwards and a bunch of
stuff changes back. This is a pain.

For the sake of simplicity and readability I'm reverting this back to
the Sqlite version. We should not check in changes made by running
migrations against Oracle.
