### PR TITLE
Move Credit Minimum & Maximum to Course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -45,6 +45,8 @@ class Course < ::ActiveRecord::Base
       repeat_limit: repeat_limit,
       units_repeat_limit: units_repeat_limit,
       offer_frequency: offer_frequency,
+      credits_minimum: credits_minimum,
+      credits_maximum: credits_maximum,
       subject: subject.to_h,
       equivalency: equivalency.to_h,
       course_attributes: course_attributes.map { |ca| ca.to_h },

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -20,8 +20,6 @@ class Section < ::ActiveRecord::Base
       number: number,
       component: component,
       location: location,
-      credits_minimum: credits_minimum,
-      credits_maximum: credits_maximum,
       notes: notes,
       instruction_mode: instruction_mode.to_h,
       grading_basis: grading_basis.to_h,

--- a/app/services/course_json_import.rb
+++ b/app/services/course_json_import.rb
@@ -9,7 +9,7 @@ class CourseJsonImport
 
     json["courses"].each do |course_json|
       course_attr = Hash.new
-      course_attr = course_json.slice("title", "description", "course_id", "catalog_number", "repeatable", "repeat_limit", "units_repeat_limit", "offer_frequency")
+      course_attr = course_json.slice("title", "description", "course_id", "catalog_number", "repeatable", "repeat_limit", "units_repeat_limit", "offer_frequency", "credits_minimum", "credits_maximum")
 
       subject = parse_resource(Subject, course_json["subject"], {"subject_id" => "subject_id", "description" => "description"})
       subject.update(campus_id: campus.id, term_id: term.id)
@@ -26,7 +26,7 @@ class CourseJsonImport
       course.course_attributes = attributes
 
       course_json["sections"].map do |section_json|
-        section = course.sections.build(section_json.slice("class_number", "number", "component", "credits_minimum", "credits_maximum", "location", "notes"))
+        section = course.sections.build(section_json.slice("class_number", "number", "component", "location", "notes"))
         section.instruction_mode = parse_resource(InstructionMode, section_json["instruction_mode"], {"instruction_mode_id" => "instruction_mode_id","description" => "description"})
         section.grading_basis = parse_resource(GradingBasis, section_json["grading_basis"], {"grading_basis_id" => "grading_basis_id", "description" => "description"})
         section.save

--- a/db/migrate/20150612144053_move_credit_attributes_to_course.rb
+++ b/db/migrate/20150612144053_move_credit_attributes_to_course.rb
@@ -1,0 +1,8 @@
+class MoveCreditAttributesToCourse < ActiveRecord::Migration
+  def change
+    remove_column(:sections, :credits_minimum)
+    remove_column(:sections, :credits_maximum)
+    add_column(:courses, :credits_minimum, :string)
+    add_column(:courses, :credits_maximum, :string)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150610180627) do
+ActiveRecord::Schema.define(version: 20150612144053) do
 
   create_table "campuses", force: :cascade do |t|
     t.string "abbreviation"
@@ -50,6 +50,8 @@ ActiveRecord::Schema.define(version: 20150610180627) do
     t.string  "units_repeat_limit"
     t.string  "repeat_limit"
     t.string  "offer_frequency"
+    t.string  "credits_minimum"
+    t.string  "credits_maximum"
   end
 
   add_index "courses", ["equivalency_id"], name: "index_courses_on_equivalency_id"
@@ -121,8 +123,6 @@ ActiveRecord::Schema.define(version: 20150610180627) do
     t.string  "number"
     t.string  "component"
     t.string  "location"
-    t.string  "credits_minimum"
-    t.string  "credits_maximum"
     t.text    "notes"
     t.integer "instruction_mode_id"
     t.integer "grading_basis_id"

--- a/doc/resources/course.yml
+++ b/doc/resources/course.yml
@@ -25,6 +25,10 @@ course:
         type: string
       offer_frequency:
         type: string
+      credits_minimum:
+        type: string
+      credits_maximum:
+        type: string
       subject:
         type: resource
       course_attributes:

--- a/doc/resources/section.yml
+++ b/doc/resources/section.yml
@@ -17,12 +17,6 @@ section:
       location:
         type: string
         description: "the resource type"
-      credits_minimum:
-        type: string
-        description: "the resource type"
-      credits_maximum:
-        type: string
-        description: "the resource type"
       instruction_mode:
         type: resource
       grading_basis:

--- a/test/fixtures/courses_example.json
+++ b/test/fixtures/courses_example.json
@@ -20,6 +20,8 @@
       "repeat_limit": "1",
       "units_repeat_limit": "4",
       "offer_frequency": "Every Fall, Spring and Summer",
+      "credits_minimum": "4",
+      "credits_maximum": "4",
       "subject": {
         "type": "subject",
         "subject_id": "PHYS",
@@ -44,8 +46,6 @@
           "number": "100",
           "component": "LEC",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -110,8 +110,6 @@
           "number": "102",
           "component": "DIS",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -166,8 +164,6 @@
           "number": "103",
           "component": "LAB",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -228,8 +224,6 @@
           "number": "104",
           "component": "DIS",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -284,8 +278,6 @@
           "number": "105",
           "component": "LAB",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -346,8 +338,6 @@
           "number": "106",
           "component": "DIS",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -402,8 +392,6 @@
           "number": "107",
           "component": "LAB",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -464,8 +452,6 @@
           "number": "108",
           "component": "DIS",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -520,8 +506,6 @@
           "number": "109",
           "component": "LAB",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -588,6 +572,8 @@
       "repeat_limit": "1",
       "units_repeat_limit": "3",
       "offer_frequency": "Every Fall",
+      "credits_minimum": "3",
+      "credits_maximum": "3",
       "subject": {
         "type": "subject",
         "subject_id": "AFRO",
@@ -616,8 +602,6 @@
           "number": "001",
           "component": "LEC",
           "location": "TCWESTBANK",
-          "credits_minimum": "3",
-          "credits_maximum": "3",
           "notes": "",
           "instruction_mode": {
             "type": "instruction_mode",

--- a/test/fixtures/no_grading_basis_for_section_102.json
+++ b/test/fixtures/no_grading_basis_for_section_102.json
@@ -20,6 +20,8 @@
       "repeat_limit": "1",
       "units_repeat_limit": "4",
       "offer_frequency": "Every Fall, Spring and Summer",
+      "credits_minimum": "4",
+      "credits_maximum": "4",
       "subject": {
         "type": "subject",
         "subject_id": "PHYS",
@@ -44,8 +46,6 @@
           "number": "100",
           "component": "LEC",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -110,8 +110,6 @@
           "number": "102",
           "component": "DIS",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -161,8 +159,6 @@
           "number": "103",
           "component": "LAB",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -223,8 +219,6 @@
           "number": "104",
           "component": "DIS",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -279,8 +273,6 @@
           "number": "105",
           "component": "LAB",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -341,8 +333,6 @@
           "number": "106",
           "component": "DIS",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -397,8 +387,6 @@
           "number": "107",
           "component": "LAB",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -459,8 +447,6 @@
           "number": "108",
           "component": "DIS",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -515,8 +501,6 @@
           "number": "109",
           "component": "LAB",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",

--- a/test/fixtures/no_instruction_mode_for_section_104.json
+++ b/test/fixtures/no_instruction_mode_for_section_104.json
@@ -20,6 +20,8 @@
       "repeat_limit": "1",
       "units_repeat_limit": "4",
       "offer_frequency": "Every Fall, Spring and Summer",
+      "credits_minimum": "4",
+      "credits_maximum": "4",
       "subject": {
         "type": "subject",
         "subject_id": "PHYS",
@@ -44,8 +46,6 @@
           "number": "100",
           "component": "LEC",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -110,8 +110,6 @@
           "number": "102",
           "component": "DIS",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -166,8 +164,6 @@
           "number": "103",
           "component": "LAB",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -228,8 +224,6 @@
           "number": "104",
           "component": "DIS",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "grading_basis": {
             "type": "grading_basis",
@@ -279,8 +273,6 @@
           "number": "105",
           "component": "LAB",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -341,8 +333,6 @@
           "number": "106",
           "component": "DIS",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -397,8 +387,6 @@
           "number": "107",
           "component": "LAB",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -459,8 +447,6 @@
           "number": "108",
           "component": "DIS",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -515,8 +501,6 @@
           "number": "109",
           "component": "LAB",
           "location": "TCEASTBANK",
-          "credits_minimum": "4",
-          "credits_maximum": "4",
           "notes": "3-hr common final exam",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -583,6 +567,8 @@
       "repeat_limit": "1",
       "units_repeat_limit": "3",
       "offer_frequency": "Every Fall",
+      "credits_minimum": "3",
+      "credits_maximum": "3",
       "subject": {
         "type": "subject",
         "subject_id": "AFRO",
@@ -611,8 +597,6 @@
           "number": "001",
           "component": "LEC",
           "location": "TCWESTBANK",
-          "credits_minimum": "3",
-          "credits_maximum": "3",
           "notes": "",
           "instruction_mode": {
             "type": "instruction_mode",


### PR DESCRIPTION
We originally placed these under section because we thought that the
credits might vary by section. This was incorrect. Credit Minimum and
Maximum are course-level data and should be part of the course resource.