### PR TITLE
Move Grading Basis to be a sub-resource of Course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,6 +1,7 @@
 class Course < ::ActiveRecord::Base
   belongs_to :subject
   belongs_to :equivalency
+  belongs_to :grading_basis
   has_and_belongs_to_many :course_attributes
   has_many :sections
 
@@ -47,6 +48,7 @@ class Course < ::ActiveRecord::Base
       offer_frequency: offer_frequency,
       credits_minimum: credits_minimum,
       credits_maximum: credits_maximum,
+      grading_basis: grading_basis.to_h,
       subject: subject.to_h,
       equivalency: equivalency.to_h,
       course_attributes: course_attributes.map { |ca| ca.to_h },

--- a/app/models/grading_basis.rb
+++ b/app/models/grading_basis.rb
@@ -1,5 +1,5 @@
 class GradingBasis < ::ActiveRecord::Base
-  has_many :sections
+  has_many :courses
 
   validates_presence_of :grading_basis_id
   validates_uniqueness_of :grading_basis_id

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,7 +1,6 @@
 class Section < ::ActiveRecord::Base
   belongs_to :course
   belongs_to :instruction_mode
-  belongs_to :grading_basis
   has_many :instructors
   has_many :meeting_patterns, -> { order "start_date" }
   has_many :combined_sections
@@ -22,7 +21,6 @@ class Section < ::ActiveRecord::Base
       location: location,
       notes: notes,
       instruction_mode: instruction_mode.to_h,
-      grading_basis: grading_basis.to_h,
       instructors: instructors.map { |i| i.to_h },
       meeting_patterns: meeting_patterns.map { |mp| mp.to_h },
       combined_sections: combined_sections.map { |cs| cs.to_h },

--- a/app/services/course_json_import.rb
+++ b/app/services/course_json_import.rb
@@ -24,11 +24,11 @@ class CourseJsonImport
 
       attributes = course_json["course_attributes"].map { |a| CourseAttribute.find_by(attribute_id: a["attribute_id"], family: a["family"]) }
       course.course_attributes = attributes
+      course.grading_basis = parse_resource(GradingBasis, course_json["grading_basis"], {"grading_basis_id" => "grading_basis_id", "description" => "description"})
 
       course_json["sections"].map do |section_json|
         section = course.sections.build(section_json.slice("class_number", "number", "component", "location", "notes"))
         section.instruction_mode = parse_resource(InstructionMode, section_json["instruction_mode"], {"instruction_mode_id" => "instruction_mode_id","description" => "description"})
-        section.grading_basis = parse_resource(GradingBasis, section_json["grading_basis"], {"grading_basis_id" => "grading_basis_id", "description" => "description"})
         section.save
 
         section_json["instructors"].each do |instructor_json|

--- a/db/migrate/20150612185245_move_grading_basis_to_course.rb
+++ b/db/migrate/20150612185245_move_grading_basis_to_course.rb
@@ -1,0 +1,6 @@
+class MoveGradingBasisToCourse < ActiveRecord::Migration
+  def change
+    remove_belongs_to(:sections, :grading_basis, index: true)
+    add_belongs_to(:courses, :grading_basis)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150612144053) do
+ActiveRecord::Schema.define(version: 20150612185245) do
 
   create_table "campuses", force: :cascade do |t|
     t.string "abbreviation"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 20150612144053) do
     t.string  "offer_frequency"
     t.string  "credits_minimum"
     t.string  "credits_maximum"
+    t.integer "grading_basis_id"
   end
 
   add_index "courses", ["equivalency_id"], name: "index_courses_on_equivalency_id"
@@ -125,7 +126,6 @@ ActiveRecord::Schema.define(version: 20150612144053) do
     t.string  "location"
     t.text    "notes"
     t.integer "instruction_mode_id"
-    t.integer "grading_basis_id"
   end
 
   add_index "sections", ["course_id"], name: "index_sections_on_course_id"

--- a/doc/resources/course.yml
+++ b/doc/resources/course.yml
@@ -29,6 +29,8 @@ course:
         type: string
       credits_maximum:
         type: string
+      grading_basis:
+        type: resource
       subject:
         type: resource
       course_attributes:

--- a/doc/resources/section.yml
+++ b/doc/resources/section.yml
@@ -19,8 +19,6 @@ section:
         description: "the resource type"
       instruction_mode:
         type: resource
-      grading_basis:
-        type: resource
       instructors:
         type: collection
       meeting_patterns:

--- a/test/fixtures/courses_example.json
+++ b/test/fixtures/courses_example.json
@@ -22,6 +22,11 @@
       "offer_frequency": "Every Fall, Spring and Summer",
       "credits_minimum": "4",
       "credits_maximum": "4",
+      "grading_basis": {
+        "type": "grading_basis",
+        "grading_basis_id": "OPT",
+        "description": "Student Option"
+      },
       "subject": {
         "type": "subject",
         "subject_id": "PHYS",
@@ -51,11 +56,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {
@@ -116,11 +116,6 @@
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
           },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
-          },
           "instructors": [
             {
               "type": "instructor",
@@ -169,11 +164,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {
@@ -230,11 +220,6 @@
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
           },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
-          },
           "instructors": [
             {
               "type": "instructor",
@@ -283,11 +268,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {
@@ -344,11 +324,6 @@
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
           },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
-          },
           "instructors": [
             {
               "type": "instructor",
@@ -397,11 +372,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {
@@ -458,11 +428,6 @@
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
           },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
-          },
           "instructors": [
             {
               "type": "instructor",
@@ -511,11 +476,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {
@@ -574,6 +534,11 @@
       "offer_frequency": "Every Fall",
       "credits_minimum": "3",
       "credits_maximum": "3",
+      "grading_basis": {
+        "type": "grading_basis",
+        "grading_basis_id": "AFV",
+        "description": "A-F or Audit"
+      },
       "subject": {
         "type": "subject",
         "subject_id": "AFRO",
@@ -607,11 +572,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "AFV",
-            "description": "A-F or Audit"
           },
           "instructors": [
             {

--- a/test/fixtures/no_grading_basis_for_section_102.json
+++ b/test/fixtures/no_grading_basis_for_section_102.json
@@ -22,6 +22,11 @@
       "offer_frequency": "Every Fall, Spring and Summer",
       "credits_minimum": "4",
       "credits_maximum": "4",
+      "grading_basis": {
+        "type": "grading_basis",
+        "grading_basis_id": "OPT",
+        "description": "Student Option"
+      },
       "subject": {
         "type": "subject",
         "subject_id": "PHYS",
@@ -51,11 +56,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {
@@ -165,11 +165,6 @@
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
           },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
-          },
           "instructors": [
             {
               "type": "instructor",
@@ -225,11 +220,6 @@
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
           },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
-          },
           "instructors": [
             {
               "type": "instructor",
@@ -278,11 +268,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {
@@ -339,11 +324,6 @@
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
           },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
-          },
           "instructors": [
             {
               "type": "instructor",
@@ -392,11 +372,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {
@@ -453,11 +428,6 @@
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
           },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
-          },
           "instructors": [
             {
               "type": "instructor",
@@ -506,11 +476,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {

--- a/test/fixtures/no_instruction_mode_for_section_104.json
+++ b/test/fixtures/no_instruction_mode_for_section_104.json
@@ -22,6 +22,11 @@
       "offer_frequency": "Every Fall, Spring and Summer",
       "credits_minimum": "4",
       "credits_maximum": "4",
+      "grading_basis": {
+        "type": "grading_basis",
+        "grading_basis_id": "OPT",
+        "description": "Student Option"
+      },
       "subject": {
         "type": "subject",
         "subject_id": "PHYS",
@@ -51,11 +56,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {
@@ -116,11 +116,6 @@
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
           },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
-          },
           "instructors": [
             {
               "type": "instructor",
@@ -169,11 +164,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {
@@ -225,11 +215,6 @@
           "component": "DIS",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
-          },
           "instructors": [
             {
               "type": "instructor",
@@ -278,11 +263,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {
@@ -339,11 +319,6 @@
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
           },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
-          },
           "instructors": [
             {
               "type": "instructor",
@@ -392,11 +367,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {
@@ -453,11 +423,6 @@
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
           },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
-          },
           "instructors": [
             {
               "type": "instructor",
@@ -506,11 +471,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "OPT",
-            "description": "Student Option"
           },
           "instructors": [
             {
@@ -569,6 +529,11 @@
       "offer_frequency": "Every Fall",
       "credits_minimum": "3",
       "credits_maximum": "3",
+      "grading_basis": {
+        "type": "grading_basis",
+        "grading_basis_id": "AFV",
+        "description": "A-F or Audit"
+      },
       "subject": {
         "type": "subject",
         "subject_id": "AFRO",
@@ -602,11 +567,6 @@
             "type": "instruction_mode",
             "instruction_mode_id": "P",
             "description": "In Person Term Based"
-          },
-          "grading_basis": {
-            "type": "grading_basis",
-            "grading_basis_id": "AFV",
-            "description": "A-F or Audit"
           },
           "instructors": [
             {


### PR DESCRIPTION
It was incorrect to put Grading Basis underneath section. It is a
Course-level attribute that we exists even when the Course has no
sections. This commit moves the association to be in the correct spot.