### PR TITLE
import Subject for the correct term

### DIFF
--- a/app/services/course_json_import.rb
+++ b/app/services/course_json_import.rb
@@ -11,8 +11,7 @@ class CourseJsonImport
       course_attr = Hash.new
       course_attr = course_json.slice("title", "description", "course_id", "catalog_number", "repeatable", "repeat_limit", "units_repeat_limit", "offer_frequency", "credits_minimum", "credits_maximum")
 
-      subject = parse_resource(Subject, course_json["subject"], {"subject_id" => "subject_id", "description" => "description"})
-      subject.update(campus_id: campus.id, term_id: term.id)
+      subject = Subject.find_or_create_by(course_json["subject"].slice("subject_id", "description").merge("term_id" => term.id, "campus_id" => campus.id))
       course_attr[:subject_id] = subject.id
 
       equivalency = parse_resource(Equivalency, course_json["equivalency"], {"equivalency_id" => "equivalency_id"})


### PR DESCRIPTION
Because subject is specific to a term and campus we need to find (or create) the subject using the term_id and campus_id, otherwise it might find a subject that already exists but is for the wrong term. This results in a validation error when the course_id has already been used for that subject.

Because this requires us to use values that are not in the json, this uses find_or_create_by directly instead of going through the #parse_resource method