### PR TITLE
Improve documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Some examples:
 - http://courses-staging.umn.edu/campuses/umncr/terms/1149/courses.json
 - http://courses-staging.umn.edu/campuses/umnro/terms/1153/courses.xml
 
+## Documentation
+
+We have documentation about the data you'll find in [doc/resources](https://github.com/umn-asr/courses/tree/master/doc/resources). For the `courses.json|xml` endpoint, you'll probably want to start with [courses.yml](https://github.com/umn-asr/courses/blob/master/doc/resources/courses.yml).
+
 ## Searching
 
 Search for courses by using the query string. You can search by:

--- a/doc/resources/course.yml
+++ b/doc/resources/course.yml
@@ -31,12 +31,16 @@ course:
         type: string
       grading_basis:
         type: resource
+        documentation: grading_basis.yml
       subject:
         type: resource
+        documentation: subject.yml
       course_attributes:
         type: collection
+        documentation: attribute.yml
       sections:
         type: collection
+        documentation: section.yml
     optional:
       equivalency:
         type: resource

--- a/doc/resources/courses.yml
+++ b/doc/resources/courses.yml
@@ -1,0 +1,10 @@
+---
+campus:
+  type: resource
+  documentation: campus.yml
+term:
+  type: resource
+  documentation: term.yml
+courses:
+  type: collection
+  documentation: course.yml

--- a/doc/resources/day.yml
+++ b/doc/resources/day.yml
@@ -7,7 +7,5 @@ day:
         description: "the resource type"
       name:
         type: string
-        description: "the resource type"
       abbreviation:
         type: string
-        description: "the resource type"

--- a/doc/resources/equivalency.yml
+++ b/doc/resources/equivalency.yml
@@ -7,4 +7,3 @@ equivalency:
         description: "the resource type"
       equivalency_id:
         type: string
-        description: "the resource type"

--- a/doc/resources/grading_basis.yml
+++ b/doc/resources/grading_basis.yml
@@ -7,7 +7,5 @@ grading_basis:
         description: "the resource type"
       grading_basis_id:
         type: string
-        description: "the resource type"
       description:
         type: string
-        description: "the resource type"

--- a/doc/resources/instruction_mode.yml
+++ b/doc/resources/instruction_mode.yml
@@ -7,7 +7,5 @@ instruction_mode:
         description: "the resource type"
       instruction_mode_id:
         type: string
-        description: "the resource type"
       description:
         type: string
-        description: "the resource type"

--- a/doc/resources/instructor.yml
+++ b/doc/resources/instructor.yml
@@ -7,10 +7,7 @@ instructor:
         description: "the resource type"
       name:
         type: string
-        description: "the resource type"
       email:
         type: string
-        description: "the resource type"
       role:
         type: string
-        description: "the resource type"

--- a/doc/resources/location.yml
+++ b/doc/resources/location.yml
@@ -7,7 +7,5 @@ location:
         description: "the resource type"
       location_id:
         type: string
-        description: "the resource type"
       description:
         type: string
-        description: "the resource type"

--- a/doc/resources/meeting_pattern.yml
+++ b/doc/resources/meeting_pattern.yml
@@ -7,17 +7,15 @@ meeting_pattern:
         description: "the resource type"
       start_time:
         type: string
-        description: "the resource type"
       end_time:
         type: string
-        description: "the resource type"
       start_date:
         type: string
-        description: "the resource type"
       end_date:
         type: string
-        description: "the resource type"
       location:
         type: resource
+        documentation: location.yml
       days:
         type: collection
+        documentation: day.yml

--- a/doc/resources/section.yml
+++ b/doc/resources/section.yml
@@ -7,25 +7,24 @@ section:
         description: "the resource type"
       class_number:
         type: string
-        description: "the resource type"
       number:
         type: string
-        description: "the resource type"
       component:
         type: string
-        description: "the resource type"
       location:
         type: string
-        description: "the resource type"
       instruction_mode:
         type: resource
+        documentation: instruction_mode.yml
       instructors:
         type: collection
+        documentation: instructor.yml
       meeting_patterns:
         type: collection
+        documentation: meeting_pattern.yml
       combined_sections:
         type: collection
+        documentation: combined_section.yml
     optional:
       notes:
         type: string
-        description: "the resource type"


### PR DESCRIPTION
As we moved a lot of Section resources into Course, it gave me a reason
to review the documentation and remember that it needed some work. This
commit fixes a few things.

First, I've added a courses.yml to describe the structure of the data
you get when visiting courses.json|xml.

Second, I've added some text to the Readme that points people to the
documentation.

Third, I've removed all of the incorrect descriptions that got
copy-and-pasted in to the documentation. When we can add real
descriptions, great. But until then I'd rather not have incorrect
descriptions.