### PR TITLE
Return id attributes as strings

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -38,7 +38,7 @@ class Course < ::ActiveRecord::Base
     {
       type: type,
       course_id: course_id,
-      id: id,
+      id: id.to_s,
       catalog_number: catalog_number,
       description: description,
       title: title,

--- a/app/models/course_attribute.rb
+++ b/app/models/course_attribute.rb
@@ -12,7 +12,7 @@ class CourseAttribute < ::ActiveRecord::Base
     {
       type: type,
       attribute_id: attribute_id,
-      id: id,
+      id: id.to_s,
       family: family
     }
   end

--- a/app/models/grading_basis.rb
+++ b/app/models/grading_basis.rb
@@ -12,7 +12,7 @@ class GradingBasis < ::ActiveRecord::Base
     {
       type: type,
       grading_basis_id: grading_basis_id,
-      id: id,
+      id: id.to_s,
       description: description
     }
   end

--- a/app/models/instruction_mode.rb
+++ b/app/models/instruction_mode.rb
@@ -12,7 +12,7 @@ class InstructionMode < ::ActiveRecord::Base
     {
       type: type,
       instruction_mode_id: instruction_mode_id,
-      id: id,
+      id: id.to_s,
       description: description
     }
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -9,7 +9,7 @@ class Location < ::ActiveRecord::Base
     {
       type: type,
       location_id: location_id,
-      id: id,
+      id: id.to_s,
       description: description
     }
   end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -14,7 +14,7 @@ class Section < ::ActiveRecord::Base
   def to_h
     {
       type: type,
-      id: id,
+      id: id.to_s,
       class_number: class_number,
       number: number,
       component: component,

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -14,7 +14,7 @@ class Subject < ::ActiveRecord::Base
     {
       type: type,
       subject_id: subject_id,
-      id: id,
+      id: id.to_s,
       description: description
     }
   end


### PR DESCRIPTION
Fixes: https://github.com/umn-asr/courses/issues/118

It's a little awkward to have to change 7 different `to_h` methods for this one tiny tweak. I thought about doing some refactoring to make this change easier, but with the looming possibility of dumping our entire persistence layer (thanks to Chad Fennel & Solr), I decided that refactoring might be wasted effort.