### PR TITLE
Fix 'not a git repo' error

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -22,6 +22,17 @@ set :ssh_options, {
   auth_methods: %w(publickey)
 }
 
+namespace :deploy do
+  desc 'Symlink Repository'
+  task :symlink_repo do
+    on roles(:app) do
+      execute :ln, "-nsf #{deploy_to}/repo #{release_path}/.git"
+    end
+  end
+end
+
+after :updating, :symlink_repo
+
 after "deploy:updated", :link_shared_tmp_folder do
   # link in the shared tmp folder
   on roles(:app) do


### PR DESCRIPTION
As originally documented
here: https://github.umn.edu/asrweb/queue_server/issues/118