### PR TITLE
Import fields required by Class Schedule pdf

### DIFF
--- a/app/models/instructor.rb
+++ b/app/models/instructor.rb
@@ -11,7 +11,8 @@ class Instructor < ::ActiveRecord::Base
       type: type,
       name: instructor_contact.name,
       email: instructor_contact.email,
-      role: instructor_role.abbreviation
+      role: instructor_role.abbreviation,
+      print: print
     }
   end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -20,6 +20,8 @@ class Section < ::ActiveRecord::Base
       component: component,
       location: location,
       notes: notes,
+      status: status,
+      print: print,
       enrollment_cap: enrollment_cap,
       instruction_mode: instruction_mode.to_h,
       instructors: instructors.map { |i| i.to_h },

--- a/app/services/course_json_import.rb
+++ b/app/services/course_json_import.rb
@@ -36,14 +36,14 @@ class CourseJsonImport
       course.grading_basis = parse_resource(GradingBasis, course_json["grading_basis"], {"grading_basis_id" => "grading_basis_id", "description" => "description"})
 
       course_json["sections"].map do |section_json|
-        section = course.sections.build(section_json.slice("class_number", "number", "component", "location", "notes", "enrollment_cap"))
+        section = course.sections.build(section_json.slice("class_number", "number", "component", "location", "notes", "status", "print", "enrollment_cap"))
         section.instruction_mode = parse_resource(InstructionMode, section_json["instruction_mode"], {"instruction_mode_id" => "instruction_mode_id","description" => "description"})
         section.save
 
         section_json["instructors"].each do |instructor_json|
           role = parse_resource(InstructorRole, instructor_json, {"role" => "abbreviation"})
           contact = parse_resource(InstructorContact, instructor_json, {"name" => "name","email" => "email"})
-          section.instructors.create(instructor_role: role, instructor_contact: contact)
+          section.instructors.create(instructor_role: role, instructor_contact: contact, print: instructor_json["print"])
         end
 
         section_json["meeting_patterns"].each do |pattern_json|

--- a/db/migrate/20160309205534_add_print_to_instructors.rb
+++ b/db/migrate/20160309205534_add_print_to_instructors.rb
@@ -1,0 +1,5 @@
+class AddPrintToInstructors < ActiveRecord::Migration
+  def change
+    add_column :instructors, :print, :string
+  end
+end

--- a/db/migrate/20160309205638_add_status_to_sections.rb
+++ b/db/migrate/20160309205638_add_status_to_sections.rb
@@ -1,0 +1,5 @@
+class AddStatusToSections < ActiveRecord::Migration
+  def change
+    add_column :sections, :status, :string
+  end
+end

--- a/db/migrate/20160309205704_add_print_to_sections.rb
+++ b/db/migrate/20160309205704_add_print_to_sections.rb
@@ -1,0 +1,5 @@
+class AddPrintToSections < ActiveRecord::Migration
+  def change
+    add_column :sections, :print, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160126190112) do
+ActiveRecord::Schema.define(version: 20160309205704) do
 
   create_table "campuses", force: :cascade do |t|
     t.string "abbreviation"
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 20160126190112) do
     t.integer "instructor_contact_id"
     t.integer "section_id"
     t.integer "instructor_role_id"
+    t.string  "print"
   end
 
   add_index "instructors", ["instructor_contact_id"], name: "index_instructors_on_instructor_contact_id"
@@ -127,6 +128,8 @@ ActiveRecord::Schema.define(version: 20160126190112) do
     t.text    "notes"
     t.integer "instruction_mode_id"
     t.string  "enrollment_cap"
+    t.string  "status"
+    t.string  "print"
   end
 
   add_index "sections", ["course_id"], name: "index_sections_on_course_id"

--- a/test/fixtures/courses_example.json
+++ b/test/fixtures/courses_example.json
@@ -52,6 +52,8 @@
           "component": "LEC",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "250",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -63,13 +65,15 @@
               "type": "instructor",
               "name": "Vincent Noireaux",
               "email": "email@umn.edu",
-              "role": "PI"
+              "role": "PI",
+              "print": "Y"
             },
             {
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             }
           ],
           "meeting_patterns": [
@@ -112,6 +116,8 @@
           "component": "DIS",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "21",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -123,13 +129,15 @@
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Jarrett Brown",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "N"
             }
           ],
           "meeting_patterns": [
@@ -162,6 +170,8 @@
           "component": "LAB",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "18",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -173,19 +183,22 @@
               "type": "instructor",
               "name": "Vincent Noireaux",
               "email": "email@umn.edu",
-              "role": "PI"
+              "role": "PI",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Jarrett Brown",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "Y"
             }
           ],
           "meeting_patterns": [
@@ -218,6 +231,8 @@
           "component": "DIS",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "21",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -229,13 +244,15 @@
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Hannah Rogers",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "N"
             }
           ],
           "meeting_patterns": [
@@ -268,6 +285,8 @@
           "component": "LAB",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "18",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -279,19 +298,22 @@
               "type": "instructor",
               "name": "Vincent Noireaux",
               "email": "email@umn.edu",
-              "role": "PI"
+              "role": "PI",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Hannah Rogers",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "Y"
             }
           ],
           "meeting_patterns": [
@@ -324,6 +346,8 @@
           "component": "DIS",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "21",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -335,13 +359,15 @@
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Kent Bodurtha",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "N"
             }
           ],
           "meeting_patterns": [
@@ -374,6 +400,8 @@
           "component": "LAB",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "18",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -385,19 +413,22 @@
               "type": "instructor",
               "name": "Vincent Noireaux",
               "email": "email@umn.edu",
-              "role": "PI"
+              "role": "PI",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Kent Bodurtha",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "Y"
             }
           ],
           "meeting_patterns": [
@@ -430,6 +461,8 @@
           "component": "DIS",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "21",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -441,13 +474,15 @@
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Michael Kreshchuk",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "N"
             }
           ],
           "meeting_patterns": [
@@ -480,6 +515,8 @@
           "component": "LAB",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "18",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -491,19 +528,22 @@
               "type": "instructor",
               "name": "Vincent Noireaux",
               "email": "email@umn.edu",
-              "role": "PI"
+              "role": "PI",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Michael Kreshchuk",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "Y"
             }
           ],
           "meeting_patterns": [
@@ -577,6 +617,8 @@
           "component": "LEC",
           "location": "TCWESTBANK",
           "notes": "",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "25",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -588,7 +630,8 @@
               "type": "instructor",
               "name": "Yuichiro Onishi",
               "email": "email@umn.edu",
-              "role": "PI"
+              "role": "PI",
+              "print": "Y"
             }
           ],
           "meeting_patterns": [

--- a/test/fixtures/no_instruction_mode_for_section_104.json
+++ b/test/fixtures/no_instruction_mode_for_section_104.json
@@ -52,6 +52,8 @@
           "component": "LEC",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "250",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -63,13 +65,15 @@
               "type": "instructor",
               "name": "Vincent Noireaux",
               "email": "email@umn.edu",
-              "role": "PI"
+              "role": "PI",
+              "print": "Y"
             },
             {
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             }
           ],
           "meeting_patterns": [
@@ -112,6 +116,8 @@
           "component": "DIS",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "21",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -123,13 +129,15 @@
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Jarrett Brown",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "N"
             }
           ],
           "meeting_patterns": [
@@ -162,6 +170,8 @@
           "component": "LAB",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "18",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -173,19 +183,22 @@
               "type": "instructor",
               "name": "Vincent Noireaux",
               "email": "email@umn.edu",
-              "role": "PI"
+              "role": "PI",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Jarrett Brown",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "Y"
             }
           ],
           "meeting_patterns": [
@@ -218,19 +231,23 @@
           "component": "DIS",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "21",
           "instructors": [
             {
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Hannah Rogers",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "N"
             }
           ],
           "meeting_patterns": [
@@ -263,6 +280,8 @@
           "component": "LAB",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "18",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -274,19 +293,22 @@
               "type": "instructor",
               "name": "Vincent Noireaux",
               "email": "email@umn.edu",
-              "role": "PI"
+              "role": "PI",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Hannah Rogers",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "Y"
             }
           ],
           "meeting_patterns": [
@@ -319,6 +341,8 @@
           "component": "DIS",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "21",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -330,13 +354,15 @@
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Kent Bodurtha",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "N"
             }
           ],
           "meeting_patterns": [
@@ -369,6 +395,8 @@
           "component": "LAB",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "18",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -380,19 +408,22 @@
               "type": "instructor",
               "name": "Vincent Noireaux",
               "email": "email@umn.edu",
-              "role": "PI"
+              "role": "PI",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Kent Bodurtha",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "Y"
             }
           ],
           "meeting_patterns": [
@@ -425,6 +456,8 @@
           "component": "DIS",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "21",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -436,13 +469,15 @@
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Michael Kreshchuk",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "N"
             }
           ],
           "meeting_patterns": [
@@ -475,6 +510,8 @@
           "component": "LAB",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "18",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -486,19 +523,22 @@
               "type": "instructor",
               "name": "Vincent Noireaux",
               "email": "email@umn.edu",
-              "role": "PI"
+              "role": "PI",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Jennifer Kroschel",
               "email": "email@umn.edu",
-              "role": "PRXY"
+              "role": "PRXY",
+              "print": "N"
             },
             {
               "type": "instructor",
               "name": "Michael Kreshchuk",
               "email": "email@umn.edu",
-              "role": "TA"
+              "role": "TA",
+              "print": "Y"
             }
           ],
           "meeting_patterns": [
@@ -572,6 +612,8 @@
           "component": "LEC",
           "location": "TCWESTBANK",
           "notes": "",
+          "status": "A",
+          "print": "Y",
           "enrollment_cap": "25",
           "instruction_mode": {
             "type": "instruction_mode",
@@ -583,7 +625,8 @@
               "type": "instructor",
               "name": "Yuichiro Onishi",
               "email": "email@umn.edu",
-              "role": "PI"
+              "role": "PI",
+              "print": "Y"
             }
           ],
           "meeting_patterns": [


### PR DESCRIPTION
Fixes: #132, #134, #135, #136, #137, #138

The class schedule pdf generation needs these fields to properly
determine:

- which sections to print (if a section's print value is N or its status
  is X, it's excluded from the PDF).
- which instructor to print for a section (if the instructor's print
  is N, it is excluded from the PDF).