### PR TITLE
Start redis for cache pool test

### DIFF
--- a/spec/lib/cache_pool_spec.rb
+++ b/spec/lib/cache_pool_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe CachePool::CachePool do
+  before :context do
+    begin
+      Process.spawn("redis-server -v", out: "/dev/null")
+    rescue
+      raise RuntimeError, "You don't appear to have Redis installed on this machine. These tests require a Redis server to be running."
+    else
+      Process.spawn("redis-server", out: "/dev/null")
+    end
+  end
+
+  after :context do
+    Process.spawn("redis-cli shutdown")
+  end
 
   describe "configuration" do
     let(:random_pool_size) { rand(100..999) }


### PR DESCRIPTION
Fixes #126

The before block also ensures that redis-server is installed and offers
a helpful error message if not.

I'm using `spawn` because the documentation recommends it over `fork`,
since fork can be platform-specific.