### PR TITLE
Pass in arrays of Terms and Campuses to CacheWarmer

### DIFF
--- a/app/services/cache_warmer.rb
+++ b/app/services/cache_warmer.rb
@@ -1,10 +1,12 @@
 class CacheWarmer
-  def self.warm(cache)
-    new(cache).warm
+  def self.warm(cache, terms, campuses)
+    new(cache, terms, campuses).warm
   end
 
-  def initialize(cache)
+  def initialize(cache, terms, campuses)
     self.cache = cache
+    self.terms = terms
+    self.campuses = campuses
   end
 
   def warm
@@ -13,7 +15,7 @@ class CacheWarmer
   end
 
   private
-  attr_accessor :cache
+  attr_accessor :cache, :terms, :campuses
 
   def clear_cache
     cache.clear
@@ -49,13 +51,5 @@ class CacheWarmer
 
   def campuses_and_terms
     campuses.product(terms)
-  end
-
-  def terms
-    Term.all
-  end
-
-  def campuses
-    Campus.all
   end
 end

--- a/lib/tasks/json_import.rake
+++ b/lib/tasks/json_import.rake
@@ -1,7 +1,7 @@
 namespace :json_import do
   desc "imports json files and updates the cache"
   task :update_all, [:directory, :file_pattern] => :directory_import do |t, args|
-    CacheWarmer.warm(CachePool::CachePool.instance.next)
+    CacheWarmer.warm(CachePool::CachePool.instance.next, Term.all.to_a, Campus.all.to_a)
     CachePool::CachePool.instance.next!
     `touch #{Rails.root}/tmp/restart.txt`
     sleep 1

--- a/spec/services/cache_warmer_spec.rb
+++ b/spec/services/cache_warmer_spec.rb
@@ -1,28 +1,29 @@
 require "rails_helper"
 
 RSpec.describe CacheWarmer do
+  before :all do
+    generate_terms
+    generate_campuses
+  end
+
   let(:cache)   { instance_double("ActiveSupport::Cache::Store") }
-  subject       { described_class.new(cache) }
+  let(:terms)     { Term.all.to_a }
+  let(:campuses)  { Campus.all.to_a }
+  subject       { described_class.new(cache, terms, campuses) }
 
   describe ".warm" do
     it "instantiates a new CacheWarmer with the supplied cache and calls #warm on it" do
       cache_warmer = instance_double(described_class)
-      expect(described_class).to receive(:new).with(cache).and_return(cache_warmer)
+      expect(described_class).to receive(:new).with(cache, terms, campuses).and_return(cache_warmer)
       expect(cache_warmer).to receive(:warm)
 
-      described_class.warm(cache)
+      described_class.warm(cache, terms, campuses)
     end
-
   end
 
   describe "warm" do
-    let(:terms)     { generate_terms }
-    let(:campuses)  { generate_campuses }
-
     before do
       allow(cache).to             receive(:clear)
-      allow(Campus).to            receive(:all).and_return(campuses)
-      allow(Term).to              receive(:all).and_return(terms)
       allow(Campus).to            receive(:fetch)
       allow(Term).to              receive(:fetch)
       allow(QueryableCourses).to  receive(:fetch)
@@ -72,11 +73,13 @@ RSpec.describe CacheWarmer do
     this_year = Time.now.strftime('%y').to_i
     years = (this_year..99).take(rand(3..6))
     years.flat_map { |year| ["1#{year}3", "1#{year}5", "1#{year}9"] }.map { |strm| Term.new(strm: strm)}
+    nil
   end
 
   def generate_campuses
     campus_abbreviations = ["UMNCR", "UMNDL", "UMNMO", "UMNRO", "UMNTC"].take(rand(2..5))
     campus_abbreviations.map { |campus_abbreviation| Campus.new(abbreviation: campus_abbreviation)}
+    nil
   end
 
   def generate_courses


### PR DESCRIPTION
Fixes #150

Trying to make it explicit what CacheWarmer needs by passing in what it
needs.

Along with this are some test adjustments. These tests didn't fail
before because the setup implicitly returned arrays instead of the object returned
by `all`. Now the tests explicitly say "Hey, these are arrays", which
should make things clearer.

CacheWarmer still has some hidden dependencies, but they weren't
related to this issue, so I left them alone.