### PR TITLE
Fix rack cache manager's use of Product

### DIFF
--- a/app/services/rack_cache_manager.rb
+++ b/app/services/rack_cache_manager.rb
@@ -1,10 +1,15 @@
 class RackCacheManager
   include Rails.application.routes.url_helpers
 
-  def self.reset
-    manager = new
+  def self.reset(terms, campuses)
+    manager = new(terms, campuses)
     manager.clear
     manager.warm
+  end
+
+  def initialize(terms, campuses)
+    self.terms = terms
+    self.campuses = campuses
   end
 
   def clear
@@ -20,20 +25,18 @@ class RackCacheManager
   end
 
   private
+
+  attr_accessor :terms, :campuses
+
   def cache_folders
     ["#{Rails.root}/tmp/cache/rack/meta", "#{Rails.root}/tmp/cache/rack/body"]
   end
 
   def base_urls_to_cache
-    campuses = Campus.all
-    terms    = Term.all
-    formats  = [:xml, :json]
-
     campuses.product(terms).inject([]) do |array, (campus, term)|
       array << campus_term_courses_url(campus.abbreviation, term.strm, format: :xml)
       array << campus_term_courses_url(campus.abbreviation, term.strm, format: :json)
       array
     end
   end
-
 end

--- a/lib/tasks/json_import.rake
+++ b/lib/tasks/json_import.rake
@@ -1,11 +1,13 @@
 namespace :json_import do
   desc "imports json files and updates the cache"
   task :update_all, [:directory, :file_pattern] => :directory_import do |t, args|
-    CacheWarmer.warm(CachePool::CachePool.instance.next, Term.all.to_a, Campus.all.to_a)
+    terms = Term.all.to_a
+    campuses = Campus.all.to_a
+    CacheWarmer.warm(CachePool::CachePool.instance.next, terms, campuses)
     CachePool::CachePool.instance.next!
     `touch #{Rails.root}/tmp/restart.txt`
     sleep 1
-    RackCacheManager.reset
+    RackCacheManager.reset(terms, campuses)
   end
 
   desc "imports class json files from the supplied directory "

--- a/spec/services/rack_cache_manager_spec.rb
+++ b/spec/services/rack_cache_manager_spec.rb
@@ -3,7 +3,14 @@ require 'rails_helper'
 RSpec.describe RackCacheManager do
   include Rails.application.routes.url_helpers
 
-  subject { described_class.new }
+  before :all do
+    generate_terms
+    generate_campuses
+  end
+  let(:terms)     { Term.all.to_a }
+  let(:campuses)  { Campus.all.to_a }
+
+  subject { described_class.new(terms, campuses) }
 
   describe ".reset" do
     it "builds a new RackCacheManager, then calls clear and warm" do
@@ -11,7 +18,7 @@ RSpec.describe RackCacheManager do
       expect(RackCacheManager).to receive(:new).and_return(instance)
       expect(instance).to receive(:clear)
       expect(instance).to receive(:warm)
-      RackCacheManager.reset
+      RackCacheManager.reset(terms, campuses)
     end
   end
 
@@ -69,5 +76,17 @@ RSpec.describe RackCacheManager do
       end
     end
   end
+end
 
+def generate_terms
+  this_year = Time.now.strftime('%y').to_i
+  years = (this_year..99).take(rand(3..6))
+  years.flat_map { |year| ["1#{year}3", "1#{year}5", "1#{year}9"] }.map { |strm| Term.new(strm: strm)}
+  nil
+end
+
+def generate_campuses
+  campus_abbreviations = ["UMNCR", "UMNDL", "UMNMO", "UMNRO", "UMNTC"].take(rand(2..5))
+  campus_abbreviations.map { |campus_abbreviation| Campus.new(abbreviation: campus_abbreviation)}
+  nil
 end


### PR DESCRIPTION
Same as #150

RackCacheManager also used `product` on an ActiveRecord Relation. This
does not work in Rails 5. Fixing the same way I fixed in #151 by passing
campus/term in as params and explicitly converting them to arrays.