### PR TITLE
Use sudo in monit command

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -40,7 +40,7 @@ namespace :deploy do
   task :configure_monit do
     on roles(:all) do
       execute "cp #{release_path}/config/monit/* /swadm/etc/monit.d/"
-      execute "monit reload"
+      execute "sudo monit reload"
     end
   end
 


### PR DESCRIPTION
Our monit command for deploying requires sudo.