### PR TITLE
Fix gemspec validation error in cache_pool

### DIFF
--- a/lib/cache_pool/cache_pool.gemspec
+++ b/lib/cache_pool/cache_pool.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |spec|
   spec.email         = ["dlagerro@umn.edu"]
 
   spec.summary       = %q{Manages a pool of redis caches.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or


### PR DESCRIPTION
Travis-CI has had validation errors when building this gem [for awhile](https://travis-ci.org/umn-asr/courses/builds/451364046)
due to not having a proper URI in the `spec.homepage`. This fixes that
so Travis-CI will run builds now.