### PR TITLE
Move import cron task to 2am

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,5 @@
 env :MAILTO, 'asr-web-errors@lists.umn.edu'
 
-every 1.day, :at => '1:30 am' do
+every 1.day, :at => '2:00 am' do
   rake "json_import:update_all['tmp/json_tmp']", output: {standard: nil}
 end


### PR DESCRIPTION
The Peoplesoft query completes around 1:50am so we sometimes miss the
1:30am window. This moves our import to 2am so we can catch the changes
after the query completes.