### PR TITLE
Fix flickering test due to id collision

### DIFF
--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Course do
     let(:term)    { Term.create(strm: "2259") }
     let(:subject) { Subject.create(subject_id: "TEST", description: "for testing", campus_id: campus.id, term_id: term.id) }
     let(:courses) {
-                      3.times do
-                        subject.courses.create(course_id: rand(1000..9999).to_s)
+                      3.times do |x|
+                        subject.courses.create(course_id: x.to_s)
                       end
 
                       subject.courses


### PR DESCRIPTION
https://travis-ci.org/umn-asr/courses/builds/604730989?utm_source=github_status&utm_medium=notification
showed that master would fail tests when run with seed 61568

rspec bisect narrowed it down to this 'minimum' reproducible command

```
bin/rspec -f d \
'./spec/lib/cache_pool_spec.rb[1:1:1,1:1:2,1:2:1:1,1:2:1:2,1:2:1:3:1,1:2:1:4:1,1:2:2:1,1:2:2:2,1:2:2:3:1,1:2:3:1]' \
'./spec/models/course_attribute_spec.rb[1:2:2,1:2:3]' \
'./spec/models/course_spec.rb[1:1:2,1:1:6,1:1:7]' \
'./spec/models/equivalency_spec.rb[1:2:2,1:2:4]' \
'./spec/models/section_spec.rb[1:2:1,1:2:2]' \
'./spec/models/subject_spec.rb[1:2:1,1:2:2,1:2:3]' \
'./spec/services/rack_cache_manager_spec.rb[1:3:2:1]' \
--seed 61568
```

What was happening is that the random number generator would assign the
same `course_id` to 2 courses created in this `let` block. And that
would prevent one of them from saving. The `course_id`s don't need to be
random, but they do need to be unique. Using the incrementer here gives
us that.