### PR TITLE
Remove BUNDLED WITH from Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,3 @@ DEPENDENCIES
   sprockets (~> 3.7.2)
   sqlite3 (~> 1.3.10)
   whenever (~> 0.9.4)
-
-BUNDLED WITH
-   2.1.4


### PR DESCRIPTION
When trying to deploy to staging today, the deployment failed with some errors
for missing gems. The version of bundler on the server differed from the
version specified here. I removed these lines and deployed to staging.
That seemed to resolve the problem.