### PR TITLE
Fix monit folder

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -44,7 +44,7 @@ namespace :deploy do
 
   task :configure_monit do
     on roles(:all) do
-      execute "cp #{release_path}/config/monit/* /swadm/etc/monit.d/"
+      execute "sudo cp #{release_path}/config/monit/* /etc/monit.d/"
       execute "sudo monit reload"
     end
   end


### PR DESCRIPTION
The same as [this commit](https://github.umn.edu/sdp/uachieve_student_transfer_articulations/pull/4/commits/6ed9c6ec1dbf11242e2d3718778729df9f91632c) in
`SDP/uachieve_student_transfer_articulations`, REHL7 runs in `/etc/` so
the configuration needs to go there.