### PR TITLE
Update deploy config for new servers

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,4 @@
 set :rails_env,  "production"
 
-server 'asr-courses-prd-web-02.oit.umn.edu',
+server 'asr-courses-prd-web-03.oit.umn.edu',
   roles: %w{web app db prod}

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,4 +1,4 @@
 set :rails_env,  "staging"
 
-server 'asr-courses-qat-web-02.oit.umn.edu',
+server 'asr-courses-qat-web-03.oit.umn.edu',
   roles: %w{web app db}


### PR DESCRIPTION
Courses has been deployed to both of the new servers succesfully.

The DNS change hasn't happened yet, but since the Ruby version was
updated awhile ago, the repo has also not been deployable to the old
servers for awhile.

Updating the servers in the deploy config now in preparation for the DNS
change, and so that it is less to remember in every new branch.