### PR TITLE
Example scope change to filter out corses for TDX 801038

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -10,6 +10,8 @@ class Course < ::ActiveRecord::Base
   validates_presence_of :subject_id, :course_id
   validates_uniqueness_of :course_id, scope: [:subject_id]
 
+  default_scope { where("LOWER(title) != 'non direct equivalent'") }
+
   scope :for_campus_and_term, ->(campus, term) { joins(:subject).where(subjects: { campus_id: campus.id, term_id: term.id }).order('subjects.description, courses.catalog_number') }
 
   def self.cache_key_for_instance(id)


### PR DESCRIPTION
TDX: https://tdx.umn.edu/TDNext/Apps/29/Tickets/TicketDet.aspx?TicketID=801038

> It would be for the Duluth campus, fall 2021 term, and should be all
> undergrad courses 1xxx - 5xxx, excluding any course noted as a 
> "non direct equivalent."

I could not find a good way to skip these in the XML -> PDF transformation, so I chose to filter them out of the query. To do this I

1. Made the above model change
2. Restarted the app 
3. Waited a day for the new data to be imported and cached
4. Once I've generated the PDF, revert the change and restart the app