### PR TITLE
Prohibit deployment when bundle-audit fails

### DIFF
--- a/script/deploy
+++ b/script/deploy
@@ -8,5 +8,8 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+echo "===> Running bundle-audit"
+bundle exec bundle-audit check --update
+
 echo "===> Deploying to $1"
 bundle exec cap "$1" deploy


### PR DESCRIPTION
Finishes [Pivotal Tracker #183558361](https://www.pivotaltracker.com/story/show/183558361).

> https://policy.umn.edu/it/securedata-appsd
>
> Deployment Phase: Prohibit deployment when software does not pass
> security requirements in the testing phase
>
> On-going Maintenance Phase: Monitor software and dependencies for
> vulnerabilities and bugs

This will eventually be run in a container as part of our standard linting. For now, this addresses the policy linked above that came up in our Gap Analysis.

* Add bundler-audit check to deploy script